### PR TITLE
Add better error output to Epub.Write() for file retreval errors.

### DIFF
--- a/epub.go
+++ b/epub.go
@@ -50,8 +50,11 @@ var ErrRetrievingFile = errors.New("Error retrieving file from source")
 // FileRetrevalError is thrown by Write in the case of a media file added with
 // AddImage, AddFont, AddCSS being unable to be read.
 type FileRetrevalError struct {
+	// File is the file that we failed to retreive.
 	File string
-	Err  error
+
+	// Err is the underlying error that we encountered attempting to retreive File.
+	Err error
 }
 
 // Error implements the error interface.

--- a/epub.go
+++ b/epub.go
@@ -47,6 +47,18 @@ var ErrFilenameAlreadyUsed = errors.New("Filename already used")
 // problem retrieving the source file that was provided
 var ErrRetrievingFile = errors.New("Error retrieving file from source")
 
+// FileRetrevalError is thrown by Write in the case of a media file added with
+// AddImage, AddFont, AddCSS being unable to be read.
+type FileRetrevalError struct {
+	File string
+	Err  error
+}
+
+// Error implements the error interface.
+func (e *FileRetrevalError) Error() string {
+	return fmt.Sprintf("Error retrieving %q from source: %+v", e.File, e.Err)
+}
+
 // Folder names used for resources inside the EPUB
 const (
 	CSSFolderName   = "css"

--- a/epub.go
+++ b/epub.go
@@ -43,9 +43,9 @@ import (
 // if the same filename is used more than once
 var ErrFilenameAlreadyUsed = errors.New("Filename already used")
 
-// ErrRetrievingFile is thrown by AddCSS, AddFont, or AddImage if there was a
-// problem retrieving the source file that was provided
-var ErrRetrievingFile = errors.New("Error retrieving file from source")
+// ErrInvalidSource is used inside FileRetrevalError for calls to
+// AddCSS, AddFont, AddImage, AddSection with an invalid file source.
+var ErrInvalidSource = errors.New("Invalid Source")
 
 // FileRetrevalError is thrown by Write in the case of a media file added with
 // AddImage, AddFont, AddCSS being unable to be read.
@@ -397,7 +397,10 @@ func (e *Epub) Title() string {
 func addMedia(source string, internalFilename string, mediaFileFormat string, mediaFolderName string, mediaMap map[string]string) (string, error) {
 	// Make sure the source file is valid before proceeding
 	if isFileSourceValid(source) == false {
-		return "", ErrRetrievingFile
+		return "", &FileRetrevalError{
+			File: source,
+			Err:  ErrInvalidSource,
+		}
 	}
 
 	if internalFilename == "" {

--- a/write.go
+++ b/write.go
@@ -298,15 +298,6 @@ func (e *Epub) writeImages(tempDir string) error {
 	return e.writeMedia(tempDir, e.images, ImageFolderName)
 }
 
-type errRetreivingFile struct {
-	file string
-	err  error
-}
-
-func (e *errRetreivingFile) Error() string {
-	return fmt.Sprintf("Error retrieving %q from source: %+v", e.file, e.err)
-}
-
 // Get images from their source and save them in the temporary directory
 func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolderName string) error {
 	if len(mediaMap) > 0 {
@@ -319,7 +310,7 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 			// Get the media file from the source
 			u, err := url.Parse(mediaSource)
 			if err != nil {
-				return &errRetreivingFile{file: mediaSource, err: err}
+				return &FileRetrevalError{File: mediaSource, Err: err}
 			}
 
 			var r io.ReadCloser
@@ -328,7 +319,7 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 			if u.Scheme == "http" || u.Scheme == "https" {
 				resp, err = http.Get(mediaSource)
 				if err != nil {
-					return &errRetreivingFile{file: mediaSource, err: err}
+					return &FileRetrevalError{File: mediaSource, Err: err}
 				}
 				r = resp.Body
 
@@ -337,7 +328,7 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 				r, err = os.Open(mediaSource)
 			}
 			if err != nil {
-				return &errRetreivingFile{file: mediaSource, err: err}
+				return &FileRetrevalError{File: mediaSource, Err: err}
 			}
 
 			mediaFilePath := filepath.Join(
@@ -367,7 +358,7 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 			if err != nil {
 				// There shouldn't be any problem with the writer, but the reader
 				// might have an issue
-				return &errRetreivingFile{file: mediaSource, err: err}
+				return &FileRetrevalError{File: mediaSource, Err: err}
 			}
 
 			mediaType := extensionMediaTypes[strings.ToLower(filepath.Ext(mediaFilename))]


### PR DESCRIPTION
Just a first pass to debug an issue I had with an ebook generator I am making, but this makes `Epub.Write` give more detailed error messages by way of creating a type that implements `error` and returning it in place of `ErrRetrievingFile`