### PR TITLE
add some thread safety to the EPUB public API

### DIFF
--- a/write.go
+++ b/write.go
@@ -67,6 +67,8 @@ const (
 // Write writes the EPUB file. The destination path must be the full path to
 // the resulting file, including filename and extension.
 func (e *Epub) Write(destFilePath string) error {
+    e.Lock()
+    defer e.Unlock()
 	tempDir, err := ioutil.TempDir("", tempDirPrefix)
 	defer func() {
 		if err := os.RemoveAll(tempDir); err != nil {


### PR DESCRIPTION
I am using this lib on pocket2kindle. It works wonderfully well but that program is very concurrency intensive and sometimes crashes when doing its work. I've implemented a borrow pattern to only one action that happens concurrently using the Epub struct. 

This PR is me trying to upstream this logic.

Some external methods are used internally so I had to hide the implementation exposing a function that does the locking stuff and call that hidden function. The functionality shouldn't have any difference, no breaking changes. It's only an improvement in the concurrency world.

BTW I've just added locks to setter/adder functions. At least in my case, I don't do any reads while working with the file.