### PR TITLE
ci: Only use EPUBCheck and send test coverage once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,11 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  # Test with EPUBCheck and send test coverage
+  test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # Test with the five most recent versions of Go
-        go: ['1.12', '1.13', '1.14', '1.15', '1.16']
-
     env:
       EPUBCHECK_VERSION: 4.2.5
-      # TODO: I think we can get rid of this once we're no longer testing with Go < 1.13
-      GO111MODULE: on
 
     steps:
     - name: Check out code
@@ -34,7 +28,11 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        # This is the latest 1.x version of Go
+        go-version: 1.x
+
+    - name: Build
+      run: go build -v ./...
 
     - name: Test
       run: go test -v -coverprofile=profile.cov ./...
@@ -43,5 +41,29 @@ jobs:
       uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: profile.cov
-        flag-name: Go-${{ matrix.go }}
-        parallel: true
+
+
+  # Test with multiple versions of Go
+  test-go-versions:
+    runs-on: ubuntu-latest
+    env:
+      # TODO: I think we can get rid of this once we're no longer testing with Go < 1.13
+      GO111MODULE: on
+    strategy:
+      matrix:
+        # Test with the five most recent versions of Go; 1.x is the latest version (1.16)
+        go: ['1.12', '1.13', '1.14', '1.15', '1.x']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,8 @@ on:
 
 jobs:
   # Test with EPUBCheck and send test coverage
-  test:
+  test-epubcheck-coverage:
     runs-on: ubuntu-latest
-    env:
-      EPUBCHECK_VERSION: 4.2.5
-
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -22,8 +19,9 @@ jobs:
     # This needs to come after the checkout, which wipes the working directory
     - name: Download EPUBCheck
       run: |
-        wget https://github.com/IDPF/epubcheck/releases/download/v${EPUBCHECK_VERSION}/epubcheck-${EPUBCHECK_VERSION}.zip
-        unzip epubcheck-${EPUBCHECK_VERSION}.zip
+        # Download the latest version of EPUBCheck
+        wget $(curl -Ls -H "Accept: application/vnd.github.v3+json" 'https://api.github.com/repos/IDPF/epubcheck/releases?per_page=1' | jq '.[0].assets[0].browser_download_url' -r)
+        unzip epubcheck-*.zip
 
     - name: Set up Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
This should make the tests quicker and hopefully simplify test coverage reporting