### PR TITLE
Fix incorrect ID generation for images in manifest

### DIFF
--- a/epub_test.go
+++ b/epub_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -594,6 +595,56 @@ func TestSetCover(t *testing.T) {
 	cleanup(testEpubFilename, tempDir)
 }
 
+func TestManifestItems(t *testing.T) {
+	testManifestItems := []string{`id="filenamewithspace.png" href="images/filename with space.png" media-type="image/png"></item>`,
+		`id="gophercolor16x16.png" href="images/gophercolor16x16.png" media-type="image/png"></item>`,
+		`id="id01filenametest.png" href="images/01filenametest.png" media-type="image/png"></item>`,
+		`id="image0005.png" href="images/image0005.png" media-type="image/png"></item>`,
+		`id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"></item>`,
+		`id="testfromfile.png" href="images/testfromfile.png" media-type="image/png"></item>`,
+	}
+
+	e := NewEpub(testEpubTitle)
+	e.AddImage(testImageFromFileSource, testImageFromFileFilename)
+	e.AddImage(testImageFromFileSource, "")
+	// In particular, we want to test these next two, which will be modified by fixXMLId()
+	e.AddImage(testImageFromFileSource, testNumberFilenameStart)
+	e.AddImage(testImageFromFileSource, testSpaceInFilename)
+	e.AddImage(testImageFromURLSource, "")
+
+	tempDir := writeAndExtractEpub(t, e, testEpubFilename)
+
+	pkgFileContent, err := ioutil.ReadFile(filepath.Join(tempDir, contentFolderName, pkgFilename))
+	if err != nil {
+		t.Errorf("Unexpected error reading package file: %s", err)
+	}
+
+	// Get just the manifest portion of the package file
+	manifestContentFromFile := string(pkgFileContent)[strings.Index(string(pkgFileContent), "<manifest>"):strings.Index(string(pkgFileContent), "</manifest>")]
+	// Convert the manifest portion of the package file to a slice
+	pkgFileManifestItems := strings.Split(manifestContentFromFile, "<item")
+	// Drop the <manifest> and </manifest>
+	pkgFileManifestItems = pkgFileManifestItems[1 : len(pkgFileManifestItems)-1]
+	// Trim whitespace for each item
+	for i := range pkgFileManifestItems {
+		pkgFileManifestItems[i] = strings.TrimSpace(pkgFileManifestItems[i])
+	}
+	// Sort the manifest items from the package file (they will be in a random order)
+	sort.Strings(pkgFileManifestItems)
+
+	// Compare the slices by converting them to strings
+	if strings.Join(pkgFileManifestItems[:], ",") != strings.Join(testManifestItems[:], ",") {
+		t.Errorf(
+			"Package file manifest items don't match\n"+
+				"Got: \n%s\n\n"+
+				"Expected: \n%s\n",
+			strings.Join(pkgFileManifestItems[:], "\n"),
+			strings.Join(testManifestItems[:], "\n"))
+	}
+
+	cleanup(testEpubFilename, tempDir)
+}
+
 func TestFilenameAlreadyUsedError(t *testing.T) {
 	e := NewEpub(testEpubTitle)
 
@@ -641,7 +692,6 @@ func TestEpubValidity(t *testing.T) {
 	e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	e.AddImage(testImageFromURLSource, "")
 	e.AddImage(testImageFromFileSource, testNumberFilenameStart)
-	e.AddImage(testImageFromFileSource, testSpaceInFilename)
 	e.SetAuthor(testEpubAuthor)
 	e.SetCover(testImagePath, "")
 	e.SetDescription(testEpubDescription)

--- a/epub_test.go
+++ b/epub_test.go
@@ -56,6 +56,8 @@ const (
 	testIdentifierTemplate    = `<dc:identifier id="pub-id">%s</dc:identifier>`
 	testImageFromFileFilename = "testfromfile.png"
 	testImageFromFileSource   = "testdata/gophercolor16x16.png"
+	testNumberFilenameStart   = "01filenametest.png"
+	testSpaceInFilename       = "filename with space.png"
 	testImageFromURLSource    = "https://golang.org/doc/gopher/gophercolor16x16.png"
 	testLangTemplate          = `<dc:language>%s</dc:language>`
 	testDescTemplate          = `<dc:description>%s</dc:description>`
@@ -638,6 +640,8 @@ func TestEpubValidity(t *testing.T) {
 	testImagePath, _ := e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	e.AddImage(testImageFromURLSource, "")
+	e.AddImage(testImageFromFileSource, testNumberFilenameStart)
+	e.AddImage(testImageFromFileSource, testSpaceInFilename)
 	e.SetAuthor(testEpubAuthor)
 	e.SetCover(testImagePath, "")
 	e.SetDescription(testEpubDescription)

--- a/write.go
+++ b/write.go
@@ -66,33 +66,6 @@ const (
 	xhtmlFolderName   = "xhtml"
 )
 
-// fixXMLId takes a string and returns an XML id compatible string.
-// https://www.w3.org/TR/REC-xml-names/#NT-NCName
-// This means it must not contain a colon (:) or whitespace and it must not
-// start with a digit, punctuation or diacritics
-func fixXMLId(id string) string {
-	if len(id) == 0 {
-		panic("No id given")
-	}
-	fixedId := []rune{}
-	for i := 0; len(id) > 0; i++ {
-		r, size := utf8.DecodeRuneInString(id)
-		if i == 0 {
-			// The new id should be prefixed with 'id' if an invalid
-			// starting character is found
-			// this is not 100% accurate, but a better check than no check
-			if unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
-				fixedId = append(fixedId, []rune("id")...)
-			}
-		}
-		if !unicode.IsSpace(r) && r != ':' {
-			fixedId = append(fixedId, r)
-		}
-		id = id[size:]
-	}
-	return string(fixedId)
-}
-
 // Write writes the EPUB file. The destination path must be the full path to
 // the resulting file, including filename and extension.
 func (e *Epub) Write(destFilePath string) error {
@@ -421,6 +394,33 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 	}
 
 	return nil
+}
+
+// fixXMLId takes a string and returns an XML id compatible string.
+// https://www.w3.org/TR/REC-xml-names/#NT-NCName
+// This means it must not contain a colon (:) or whitespace and it must not
+// start with a digit, punctuation or diacritics
+func fixXMLId(id string) string {
+	if len(id) == 0 {
+		panic("No id given")
+	}
+	fixedId := []rune{}
+	for i := 0; len(id) > 0; i++ {
+		r, size := utf8.DecodeRuneInString(id)
+		if i == 0 {
+			// The new id should be prefixed with 'id' if an invalid
+			// starting character is found
+			// this is not 100% accurate, but a better check than no check
+			if unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
+				fixedId = append(fixedId, []rune("id")...)
+			}
+		}
+		if !unicode.IsSpace(r) && r != ':' {
+			fixedId = append(fixedId, r)
+		}
+		id = id[size:]
+	}
+	return string(fixedId)
 }
 
 // Write the mimetype file

--- a/write.go
+++ b/write.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // UnableToCreateEpubError is thrown by Write if it cannot create the destination EPUB file
@@ -63,6 +65,33 @@ const (
 	tempDirPrefix     = "go-epub"
 	xhtmlFolderName   = "xhtml"
 )
+
+// fixXMLId takes a string and returns an XML id compatible string.
+// https://www.w3.org/TR/REC-xml-names/#NT-NCName
+// This means it must not contain a colon (:) or whitespace and it must not
+// start with a digit, punctuation or diacritics
+func fixXMLId(id string) string {
+	if len(id) == 0 {
+		panic("No id given")
+	}
+	fixedId := []rune{}
+	for i := 0; len(id) > 0; i++ {
+		r, size := utf8.DecodeRuneInString(id)
+		if i == 0 {
+			// The new id should be prefixed with 'id' if an invalid
+			// starting character is found
+			// this is not 100% accurate, but a better check than no check
+			if unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
+				fixedId = append(fixedId, []rune("id")...)
+			}
+		}
+		if !unicode.IsSpace(r) && r != ':' {
+			fixedId = append(fixedId, r)
+		}
+		id = id[size:]
+	}
+	return string(fixedId)
+}
 
 // Write writes the EPUB file. The destination path must be the full path to
 // the resulting file, including filename and extension.
@@ -387,7 +416,7 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 			}
 
 			// Add the file to the OPF manifest
-			e.pkg.addToManifest(mediaFilename, filepath.Join(mediaFolderName, mediaFilename), mediaType, mediaProperties)
+			e.pkg.addToManifest(fixXMLId(mediaFilename), filepath.Join(mediaFolderName, mediaFilename), mediaType, mediaProperties)
 		}
 	}
 


### PR DESCRIPTION
The media name was taken as the xml id for the manifest. This
breaks XML rules when for example the image file name

* starts with a number
* contains spaces or colons