### PR TITLE
feat: add support for inline dataurl as media

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test with the five most recent versions of Go; 1.x is the latest version (1.16)
-        go: ['1.12', '1.13', '1.14', '1.15', '1.x']
+        go: ['1.15', '1.x']
 
     steps:
     - uses: actions/checkout@v2

--- a/fetchmedia.go
+++ b/fetchmedia.go
@@ -1,0 +1,97 @@
+package epub
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gabriel-vasile/mimetype"
+	"github.com/vincent-petithory/dataurl"
+)
+
+// fetchMedia from mediaSource into mediaFolderPath as mediaFilename returning its type.
+// the mediaSource can be a URL, a local path or an inline dataurl (as specified in RFC 2397)
+func fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) (mediaType string, err error) {
+
+	mediaFilePath := filepath.Join(
+		mediaFolderPath,
+		mediaFilename,
+	)
+	// failfast, create the output file handler at the begining, if we cannot write the file, bail out
+	w, err := os.Create(mediaFilePath)
+	if err != nil {
+		return "", fmt.Errorf("unable to create file: %s", err)
+	}
+	defer w.Close()
+	var source io.ReadCloser
+	fetchErrors := make([]error, 0)
+	for _, f := range []func(string) (io.ReadCloser, error){
+		fetchMediaFromURL,
+		fetchMediaLocally,
+		fetchMediaDataURL,
+	} {
+		var err error
+		source, err = f(mediaSource)
+		if err != nil {
+			fetchErrors = append(fetchErrors, err)
+			continue
+		}
+		break
+	}
+	if source == nil {
+		return "", &FileRetrievalError{Source: mediaSource, Err: fetchError(fetchErrors)}
+
+	}
+	defer source.Close()
+	_, err = io.Copy(w, source)
+	if err != nil {
+		// There shouldn't be any problem with the writer, but the reader
+		// might have an issue
+		return "", &FileRetrievalError{Source: mediaSource, Err: err}
+	}
+	// Detect the mediaType
+	w.Seek(0, io.SeekStart)
+	mime, err := mimetype.DetectReader(w)
+	if err != nil {
+		panic(err)
+	}
+	return mime.String(), nil
+}
+
+func fetchMediaFromURL(mediaSource string) (io.ReadCloser, error) {
+	resp, err := http.Get(mediaSource)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode > 400 {
+		return nil, errors.New("cannot get file, bad return code")
+	}
+	return resp.Body, nil
+}
+
+func fetchMediaLocally(mediaSource string) (io.ReadCloser, error) {
+	return os.Open(mediaSource)
+}
+
+func fetchMediaDataURL(mediaSource string) (io.ReadCloser, error) {
+	data, err := dataurl.DecodeString(mediaSource)
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.NopCloser(bytes.NewReader(data.Data)), nil
+}
+
+type fetchError []error
+
+func (f fetchError) Error() string {
+	var message string
+	for _, err := range f {
+		message = fmt.Sprintf("%v\n %v", message, err.Error())
+	}
+	return message
+}

--- a/fetchmedia.go
+++ b/fetchmedia.go
@@ -60,7 +60,14 @@ func fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) (mediaType s
 	if err != nil {
 		panic(err)
 	}
-	return mime.String(), nil
+	// Is it CSS?
+	mtype := mime.String()
+	if mime.Is("text/plain") {
+		if filepath.Ext(mediaSource) == ".css" || filepath.Ext(mediaFilename) == ".css" {
+			mtype = "text/css"
+		}
+	}
+	return mtype, nil
 }
 
 func fetchMediaFromURL(mediaSource string) (io.ReadCloser, error) {

--- a/fetchmedia_test.go
+++ b/fetchmedia_test.go
@@ -1,0 +1,116 @@
+package epub
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var golangFavicon = strings.Replace(`AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAD///8AVE44//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2//7hdv/+4Xb/
+/uF2/1ROOP////8A////AFROOP/+4Xb//uF2//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2//7hdv/+
+4Xb//uF2//7hdv9UTjj/////AP///wBUTjj//uF2//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2//7h
+dv/+4Xb//uF2//7hdv/+4Xb/VE44/////wD///8AVE44//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2
+//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2/1ROOP////8A////AFROOP/+4Xb//uF2//7hdv/+4Xb/
+/uF2//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2//7hdv9UTjj/////AP///wBUTjj//uF2//7hdv/+
+4Xb//uF2//7hdv/+4Xb//uF2//7hdv/+4Xb//uF2//7hdv/+4Xb/VE44/////wD///8AVE44//7h
+dv/+4Xb//uF2//7hdv/+4Xb/z7t5/8Kyev/+4Xb//993///dd///3Xf//uF2/1ROOP////8A////
+AFROOP/+4Xb//uF2//7hdv//4Hn/dIzD//v8///7/P//dIzD//7hdv//3Xf//913//7hdv9UTjj/
+////AP///wBUTjj//uF2///fd//+4Xb//uF2/6ajif90jMP/dIzD/46Zpv/+4Xb//+F1///feP/+
+4Xb/VE44/////wD///8AVE44//7hdv/z1XT////////////Is3L/HyAj/x8gI//Is3L/////////
+///z1XT//uF2/1ROOP////8A19nd/1ROOP/+4Xb/5+HS//v+//8RExf/Liwn//7hdv/+4Xb/5+HS
+//v8//8RExf/Liwn//7hdv9UTjj/19nd/1ROOP94aDT/yKdO/+fh0v//////ERMX/y4sJ//+4Xb/
+/uF2/+fh0v//////ERMX/y4sJ//Ip07/dWU3/1ROOP9UTjj/yKdO/6qSSP/Is3L/9fb7//f6///I
+s3L//uF2//7hdv/Is3L////////////Is3L/qpJI/8inTv9UTjj/19nd/1ROOP97c07/qpJI/8in
+Tv/Ip07//uF2//7hdv/+4Xb//uF2/8zBlv/Kv4//pZJU/3tzTv9UTjj/19nd/////wD///8A4eLl
+/6CcjP97c07/e3NO/1dOMf9BOiX/TkUn/2VXLf97c07/e3NO/6CcjP/h4uX/////AP///wD///8A
+////AP///wD///8A////AP///wDq6/H/3N/j/9fZ3f/q6/H/////AP///wD///8A////AP///wD/
+//8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAA==`, "\n", "", -1)
+
+func Test_fetchMedia(t *testing.T) {
+	filename := "gophercolor16x16.png"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := os.Open(filepath.Join("testdata", filename))
+		if err != nil {
+			t.Fatal("cannot open testdata")
+		}
+		defer data.Close()
+		io.Copy(w, data)
+	}))
+	defer ts.Close()
+
+	type args struct {
+		mediaSource     string
+		mediaFolderPath string
+		mediaFilename   string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantMediaType string
+		wantErr       bool
+	}{
+		{
+			"URL request with test filename",
+			args{
+				mediaSource:     ts.URL,
+				mediaFolderPath: t.TempDir(),
+				mediaFilename:   "test",
+			},
+			"image/png",
+			false,
+		},
+		{
+			"local file with test filename",
+			args{
+				mediaSource:     filepath.Join("testdata", filename),
+				mediaFolderPath: t.TempDir(),
+				mediaFilename:   "test",
+			},
+			"image/png",
+			false,
+		},
+		{
+			"dataurl media with test filename",
+			args{
+				mediaSource:     `data:image/vnd.microsoft.icon;name=golang%20favicon;base64,` + golangFavicon,
+				mediaFolderPath: t.TempDir(),
+				mediaFilename:   "test",
+			},
+			"image/x-icon",
+			false,
+		},
+		{
+			"bad request",
+			args{
+				mediaSource:     "badRequest",
+				mediaFolderPath: t.TempDir(),
+				mediaFilename:   "test",
+			},
+			"",
+			true,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMediaType, err := fetchMedia(tt.args.mediaSource, tt.args.mediaFolderPath, tt.args.mediaFilename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fetchMedia() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotMediaType != tt.wantMediaType {
+				t.Errorf("fetchMedia() = %v, want %v", gotMediaType, tt.wantMediaType)
+			}
+			if _, err := os.Stat(filepath.Join(tt.args.mediaFolderPath, tt.args.mediaFilename)); os.IsNotExist(err) {
+				// path/to/whatever does not exist
+				t.Errorf("fetchMedia(): file %v does not exist (source %v): %v", filepath.Join(tt.args.mediaFolderPath, tt.args.mediaFilename), tt.args.mediaSource, err)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/gabriel-vasile/mimetype v1.3.1
 	github.com/gofrs/uuid v3.1.0+incompatible
+	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/bmaupin/go-epub
 
-require github.com/gofrs/uuid v3.1.0+incompatible
+go 1.16
+
+require (
+	github.com/gabriel-vasile/mimetype v1.3.1
+	github.com/gofrs/uuid v3.1.0+incompatible
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bmaupin/go-epub
 
-go 1.16
+go 1.15
 
 require (
 	github.com/gabriel-vasile/mimetype v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/gabriel-vasile/mimetype v1.3.1 h1:qevA6c2MtE1RorlScnixeG0VA1H4xrXyhyX3oWBynNQ=
+github.com/gabriel-vasile/mimetype v1.3.1/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/gofrs/uuid v3.1.0+incompatible h1:q2rtkjaKT4YEr6E1kamy0Ha4RtepWlQBedyHx0uzKwA=
 github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 h1:Ugb8sMTWuWRC3+sz5WeN/4kejDx9BvIwnPUiJBjJE+8=
+golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/gabriel-vasile/mimetype v1.3.1 h1:qevA6c2MtE1RorlScnixeG0VA1H4xrXyhyX
 github.com/gabriel-vasile/mimetype v1.3.1/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
 github.com/gofrs/uuid v3.1.0+incompatible h1:q2rtkjaKT4YEr6E1kamy0Ha4RtepWlQBedyHx0uzKwA=
 github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 h1:uxE3GYdXIOfhMv3unJKETJEhw78gvzuQqRX/rVirc2A=
+github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 h1:Ugb8sMTWuWRC3+sz5WeN/4kejDx9BvIwnPUiJBjJE+8=
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/write.go
+++ b/write.go
@@ -21,19 +21,6 @@ func (e *UnableToCreateEpubError) Error() string {
 	return fmt.Sprintf("Error creating EPUB at %q: %+v", e.Path, e.Err)
 }
 
-var extensionMediaTypes = map[string]string{
-	".css":   mediaTypeCSS,
-	".gif":   "image/gif",
-	".jpeg":  mediaTypeJpeg,
-	".jpg":   mediaTypeJpeg,
-	".otf":   "application/vnd.ms-opentype",
-	".png":   "image/png",
-	".svg":   "image/svg+xml",
-	".ttf":   "application/font-sfnt",
-	".woff":  "application/font-woff",
-	".woff2": "font/woff2",
-}
-
 const (
 	containerFilename     = "container.xml"
 	containerFileTemplate = `<?xml version="1.0" encoding="UTF-8"?>

--- a/write.go
+++ b/write.go
@@ -5,15 +5,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/gabriel-vasile/mimetype"
 )
 
 // UnableToCreateEpubError is thrown by Write if it cannot create the destination EPUB file
@@ -319,80 +314,14 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 	if len(mediaMap) > 0 {
 		mediaFolderPath := filepath.Join(tempDir, contentFolderName, mediaFolderName)
 		if err := os.Mkdir(mediaFolderPath, dirPermissions); err != nil {
-			panic(fmt.Sprintf("Unable to create directory: %s", err))
+			return fmt.Errorf("unable to create directory: %s", err)
 		}
 
 		for mediaFilename, mediaSource := range mediaMap {
-			// Get the media file from the source
-			u, err := url.Parse(mediaSource)
+			mediaType, err := fetchMedia(mediaSource, mediaFolderPath, mediaFilename)
 			if err != nil {
-				return &FileRetrievalError{Source: mediaSource, Err: err}
+				return err
 			}
-
-			var r io.ReadCloser
-			var resp *http.Response
-			var mediaType string
-			// If it's a URL
-			if u.Scheme == "http" || u.Scheme == "https" {
-				resp, err = http.Get(mediaSource)
-				if err != nil {
-					return &FileRetrievalError{Source: mediaSource, Err: err}
-				}
-				r = resp.Body
-
-				// Otherwise, assume it's a local file
-			} else {
-				r, err = os.Open(mediaSource)
-			}
-			if err != nil {
-				return &FileRetrievalError{Source: mediaSource, Err: err}
-			}
-
-			mediaFilePath := filepath.Join(
-				mediaFolderPath,
-				mediaFilename,
-			)
-
-			// Add the file to the EPUB temp directory
-			w, err := os.Create(mediaFilePath)
-			if err != nil {
-				panic(fmt.Sprintf("Unable to create file: %s", err))
-			}
-
-			_, err = io.Copy(w, r)
-			// Close the reader and writer manually. If we use a defer instead,
-			// they won't close until the function exits.
-			func() {
-				if err := r.Close(); err != nil {
-					panic(err)
-				}
-			}()
-
-			func() {
-				if err := w.Close(); err != nil {
-					panic(err)
-				}
-			}()
-			if err != nil {
-				// There shouldn't be any problem with the writer, but the reader
-				// might have an issue
-				return &FileRetrievalError{Source: mediaSource, Err: err}
-			}
-
-			if mediaType == "" {
-				mime, _ := mimetype.DetectFile(mediaFilePath)
-				mediaType = mime.String()
-			}
-			if mediaType == "" {
-
-				mediaType = extensionMediaTypes[strings.ToLower(filepath.Ext(mediaFilename))]
-				if mediaType == "" {
-					panic(fmt.Sprintf(
-						"Unmatched file extension, media type not set for file: %s",
-						mediaFilename))
-				}
-			}
-
 			// The cover image has a special value for the properties attribute
 			mediaProperties := ""
 			if mediaFilename == e.cover.imageFilename {
@@ -403,7 +332,6 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 			e.pkg.addToManifest(fixXMLId(mediaFilename), filepath.Join(mediaFolderName, mediaFilename), mediaType, mediaProperties)
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
### This PR introduces a support for inline-media (dataurl encoded).
To achieve this feature, there is a need to `tweak` the writeMedia method.
To make things maintainable and testable, instead of overloading the method, I created an external function to fetch the media.
This function relies on sub-functions with this signature:

```go
func(mediaSource string) (io.ReadCloser, error)
```

Three subfunctions are implemented:
- `fetchMediaFromURL` fetches a media from a URL (the standard behaviour)
- `fetchMediaLocally` get the media from the local FR
- `fetchMediaDataURL` fetch the media from a RFC 2397 encoded scheme

The main `fetchMedia` function tries all of the functions and stop when one exist without error. If none of them exit without error, the `FileRetrievalError` error is raised containing all the errors of all the checks for analysis.

As requested, a set of unit-test has been added to maintain the test coverage.