### PR TITLE
ci: Explicitly test with Go 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
       # Don't cancel remaining jobs when one matrix job fails
       fail-fast: false
       matrix:
-        # Test with the five most recent versions of Go; 1.x is the latest version (1.16)
-        go: ['1.15', '1.x']
+        # 1.x is the latest version of Go
+        go: ['1.15', '1.16', '1.x']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
   # Test with multiple versions of Go
   test-go-versions:
     runs-on: ubuntu-latest
-    env:
-      # TODO: I think we can get rid of this once we're no longer testing with Go < 1.13
-      GO111MODULE: on
     strategy:
       # Don't cancel remaining jobs when one matrix job fails
       fail-fast: false


### PR DESCRIPTION
It looks like 1.x isn't pointing to 1.17 yet, but it should be imminent as it was just released

Closes #46