### PR TITLE
Validation functions and custom http client

### DIFF
--- a/epub.go
+++ b/epub.go
@@ -161,7 +161,7 @@ func NewEpub(title string) *Epub {
 // file that can be used in EPUB sections in the format:
 // ../CSSFolderName/internalFilename
 //
-// The CSS source should either be a URL or a path to a local file; in either
+// The CSS source should either be a URL, a path to a local file or a embeded dataurl; in either
 // case, the CSS file will be retrieved and stored in the EPUB.
 //
 // The internal filename will be used when storing the CSS file in the EPUB
@@ -182,7 +182,7 @@ func (e *Epub) addCSS(source string, internalFilename string) (string, error) {
 // file that can be used in EPUB sections in the format:
 // ../FontFolderName/internalFilename
 //
-// The font source should either be a URL or a path to a local file; in either
+// The font source should either be a URL, a path to a local file or a embeded dataurl; in either
 // case, the font file will be retrieved and stored in the EPUB.
 //
 // The internal filename will be used when storing the font file in the EPUB
@@ -199,7 +199,7 @@ func (e *Epub) AddFont(source string, internalFilename string) (string, error) {
 // file that can be used in EPUB sections in the format:
 // ../ImageFolderName/internalFilename
 //
-// The image source should either be a URL or a path to a local file; in either
+// The image source should either be a URL, a path to a local file or a embeded dataurl; in either
 // case, the image file will be retrieved and stored in the EPUB.
 //
 // The internal filename will be used when storing the image file in the EPUB

--- a/epub_test.go
+++ b/epub_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// Set this to false to not delete the generated test EPUB file
-	doCleanup             = false
+	doCleanup             = true
 	testAuthorTemplate    = `<dc:creator id="creator">%s</dc:creator>`
 	testContainerContents = `<?xml version="1.0" encoding="UTF-8"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">

--- a/epub_test.go
+++ b/epub_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// Set this to false to not delete the generated test EPUB file
-	doCleanup             = true
+	doCleanup             = false
 	testAuthorTemplate    = `<dc:creator id="creator">%s</dc:creator>`
 	testContainerContents = `<?xml version="1.0" encoding="UTF-8"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">

--- a/fetchmedia.go
+++ b/fetchmedia.go
@@ -14,9 +14,39 @@ import (
 	"github.com/vincent-petithory/dataurl"
 )
 
+// grabber is a top level structure that allows a custom http client.
+// if onlyChecl is true, the methods will not perform actual grab to spare memory and bandwidth
+type grabber struct {
+	*http.Client
+}
+
+func (g grabber) checkMedia(mediaSource string) error {
+	fetchErrors := make([]error, 0)
+	for _, f := range []func(string, bool) (io.ReadCloser, error){
+		g.fetchMediaFromURL,
+		g.fetchMediaLocally,
+		g.fetchMediaDataURL,
+	} {
+		var err error
+		source, err := f(mediaSource, true)
+		if source != nil {
+			source.Close()
+		}
+		if err != nil {
+			fetchErrors = append(fetchErrors, err)
+			continue
+		}
+		break
+	}
+	if len(fetchErrors) == 3 {
+		return &FileRetrievalError{Source: mediaSource, Err: fetchError(fetchErrors)}
+	}
+	return nil
+}
+
 // fetchMedia from mediaSource into mediaFolderPath as mediaFilename returning its type.
 // the mediaSource can be a URL, a local path or an inline dataurl (as specified in RFC 2397)
-func fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) (mediaType string, err error) {
+func (g grabber) fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) (mediaType string, err error) {
 
 	mediaFilePath := filepath.Join(
 		mediaFolderPath,
@@ -30,13 +60,13 @@ func fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) (mediaType s
 	defer w.Close()
 	var source io.ReadCloser
 	fetchErrors := make([]error, 0)
-	for _, f := range []func(string) (io.ReadCloser, error){
-		fetchMediaFromURL,
-		fetchMediaLocally,
-		fetchMediaDataURL,
+	for _, f := range []func(string, bool) (io.ReadCloser, error){
+		g.fetchMediaFromURL,
+		g.fetchMediaLocally,
+		g.fetchMediaDataURL,
 	} {
 		var err error
-		source, err = f(mediaSource)
+		source, err = f(mediaSource, false)
 		if err != nil {
 			fetchErrors = append(fetchErrors, err)
 			continue
@@ -70,8 +100,14 @@ func fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) (mediaType s
 	return mtype, nil
 }
 
-func fetchMediaFromURL(mediaSource string) (io.ReadCloser, error) {
-	resp, err := http.Get(mediaSource)
+func (g grabber) fetchMediaFromURL(mediaSource string, onlyCheck bool) (io.ReadCloser, error) {
+	var resp *http.Response
+	var err error
+	if onlyCheck {
+		resp, err = g.Head(mediaSource)
+	} else {
+		resp, err = g.Get(mediaSource)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -81,11 +117,20 @@ func fetchMediaFromURL(mediaSource string) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-func fetchMediaLocally(mediaSource string) (io.ReadCloser, error) {
+func (g grabber) fetchMediaLocally(mediaSource string, onlyCheck bool) (io.ReadCloser, error) {
+	if onlyCheck {
+		f, err := os.Open(mediaSource)
+		f.Close()
+		return nil, err
+	}
 	return os.Open(mediaSource)
 }
 
-func fetchMediaDataURL(mediaSource string) (io.ReadCloser, error) {
+func (g grabber) fetchMediaDataURL(mediaSource string, onlyCheck bool) (io.ReadCloser, error) {
+	if onlyCheck {
+		_, err := dataurl.DecodeString(mediaSource)
+		return nil, err
+	}
 	data, err := dataurl.DecodeString(mediaSource)
 	if err != nil {
 		return nil, err

--- a/fetchmedia_test.go
+++ b/fetchmedia_test.go
@@ -144,7 +144,8 @@ func Test_fetchMedia(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotMediaType, err := fetchMedia(tt.args.mediaSource, tt.args.mediaFolderPath, tt.args.mediaFilename)
+			g := &grabber{http.DefaultClient}
+			gotMediaType, err := g.fetchMedia(tt.args.mediaSource, tt.args.mediaFolderPath, tt.args.mediaFilename)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fetchMedia() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/perf_test.go
+++ b/perf_test.go
@@ -1,0 +1,46 @@
+package epub
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkAddImage_http(b *testing.B) {
+	filename := "gophercolor16x16.png"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/image.png", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			data, err := os.Open(filepath.Join("testdata", filename))
+			if err != nil {
+				b.Fatal("cannot open testdata")
+			}
+			defer data.Close()
+			io.Copy(w, data)
+		case "HEAD":
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	e := NewEpub("test")
+	for i := 0; i < b.N; i++ {
+		_, err := e.AddImage(ts.URL+"/image.png", "")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+func BenchmarkAddImage_file(b *testing.B) {
+	e := NewEpub("test")
+	for i := 0; i < b.N; i++ {
+		_, err := e.AddImage("testdata/gophercolor16x16.png", "")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/write.go
+++ b/write.go
@@ -305,7 +305,7 @@ func (e *Epub) writeMedia(tempDir string, mediaMap map[string]string, mediaFolde
 		}
 
 		for mediaFilename, mediaSource := range mediaMap {
-			mediaType, err := fetchMedia(mediaSource, mediaFolderPath, mediaFilename)
+			mediaType, err := grabber{(e.Client)}.fetchMedia(mediaSource, mediaFolderPath, mediaFilename)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Custom HTTP Client

This PR introduces the ability to add a custom http client to fetch the data (see https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779 for the why)

## data-url

### Fix the documentation (#48 )

The documentation mention that it is possible to use a data URL

### Validation function

- The validation function in the building phase is relaying on the same function used in the writing phase
- In the building phase, HEAD requests are issued to spare bandwidth. On top of that this will validate that the file is actually available.