### PR TITLE
feat: new WriteTo method.

### DIFF
--- a/write_test.go
+++ b/write_test.go
@@ -13,6 +13,6 @@ func TestEpubWriteTo(t *testing.T) {
 		t.Fatal(err)
 	}
 	if int64(len(b.Bytes())) != n {
-		t.Fail()
+		t.Fatalf("Expected size %v, got %v", len(b.Bytes()), n)
 	}
 }

--- a/write_test.go
+++ b/write_test.go
@@ -1,0 +1,18 @@
+package epub
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEpubWriteTo(t *testing.T) {
+	e := NewEpub(testEpubTitle)
+	var b bytes.Buffer
+	n, err := e.WriteTo(&b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(b.Bytes())) != n {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
As exposed in #52 , I introduce this method to write the zipfile to an `io.Writer`.
This can be helpful if the EPUB generation is embedded in a webserver for example.

This PR introduces the `WriteTo(w io.Writer) (int64, error)` method to the EPUB structure. 
The EPUB structure is therefore fulfilling the [`io.WriterTo`](https://pkg.go.dev/io#WriterTo) interface.

The `Write` method has been modified to use this new method. The `destination` is a file created within the Write method.

The existing tests should be enough to validate the new method. I added one new test to validate the counter of the bytes written.