### PR TITLE
Add epub namespace to sections

### DIFF
--- a/epub.go
+++ b/epub.go
@@ -283,6 +283,7 @@ func (e *Epub) addSection(body string, sectionTitle string, internalFilename str
 
 	x := newXhtml(body)
 	x.setTitle(sectionTitle)
+	x.setXmlnsEpub(xmlnsEpub)
 
 	if internalCSSPath != "" {
 		x.setCSS(internalCSSPath)

--- a/epub_test.go
+++ b/epub_test.go
@@ -34,7 +34,7 @@ const (
 	testCoverCSSSource       = "testdata/cover.css"
 	testCoverContentTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
   <head>
     <title>%s</title>
     <link rel="stylesheet" type="text/css" href="%s"></link>
@@ -88,7 +88,7 @@ const (
 	<p>This is a paragraph.</p>`
 	testSectionContentTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
   <head>
     <title>%s</title>
   </head>


### PR DESCRIPTION
Generating an epub with custom attributes fails with the error: `ERROR: Parsing failed: Namespace prefix epub for type on a is not defined...`

This is because the document requires the `http://www.idpf.org/2007/ops` namespace declared (see [EPUB Content Document Reference](https://www.w3.org/publishing/epub3/epub-contentdocs.html#sec-epub-type-attribute) for example).

This PR adds the namespace to any section generated.

Another option would be to give the author the ability to add it manually, but in most circumstances, I assume that the content is just added blindly and the developer is not aware of the presence of epub tags.