### PR TITLE
[fix-bug] image with same URL should not add twice more reliable id image tag fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 # Source: https://github.com/actions/starter-workflows/blob/main/ci/go.yml
-
 name: CI
 
 on:
@@ -8,7 +7,25 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
+  # Test golangci-lint for go-version define in go.mod
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc #v3.7.0
+        with:
+          version: latest
+          only-new-issues: true
+
   # Test with EPUBCheck and send test coverage
   test-epubcheck:
     runs-on: ubuntu-latest

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 bmaupin
+Copyright (c) 2023 Go-Shiori team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-[![CI](https://github.com/bmaupin/go-epub/workflows/CI/badge.svg)](https://github.com/bmaupin/go-epub/actions)
-[![Coverage Status](https://coveralls.io/repos/github/bmaupin/go-epub/badge.svg)](https://coveralls.io/github/bmaupin/go-epub)
-[![Go Report Card](https://goreportcard.com/badge/github.com/bmaupin/go-epub)](https://goreportcard.com/report/github.com/bmaupin/go-epub)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/bmaupin/go-epub/blob/master/LICENSE)
-[![GoDoc](https://godoc.org/github.com/bmaupin/go-epub?status.svg)](https://godoc.org/github.com/bmaupin/go-epub)
+[![CI](https://github.com/go-shiori/go-epub/workflows/CI/badge.svg)](github.com/go-shiori/go-epub/actions)
+[![Coverage Status](https://coveralls.io/repos/github/go-shiori/go-epub/badge.svg)](https://coveralls.io/github/go-shiori/go-epub)
+[![Go Report Card](https://goreportcard.com/badge/github.com/go-shiori/go-epub)](https://goreportcard.com/report/github.com/go-shiori/go-epub)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/go-shiori/go-epub/blob/master/LICENSE)
+[![GoDoc](https://godoc.org/github.com/go-shiori/go-epub?status.svg)](https://godoc.org/github.com/go-shiori/go-epub)
 
 ---
 
 ### Features
-- [Documented API](https://godoc.org/github.com/bmaupin/go-epub)
+- [Documented API](https://godoc.org/github.com/go-shiori/go-epub)
 - Creates valid EPUB 3.0 files
-- Adds an additional EPUB 2.0 table of contents ([as seen here](https://github.com/bmaupin/epub-samples)) for maximum compatibility
+- Adds an additional EPUB 2.0 table of contents for maximum compatibility
 - Includes support for adding CSS, images, and fonts
-
-For an example of actual usage, see https://github.com/bmaupin/go-docs-epub
 
 ### Contributions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/go-shiori/go-epub/workflows/CI/badge.svg)](github.com/go-shiori/go-epub/actions)
+[![CI](https://github.com/go-shiori/go-epub/workflows/CI/badge.svg)](https://github.com/go-shiori/go-epub/actions)
 [![Coverage Status](https://coveralls.io/repos/github/go-shiori/go-epub/badge.svg)](https://coveralls.io/github/go-shiori/go-epub)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-shiori/go-epub)](https://goreportcard.com/report/github.com/go-shiori/go-epub)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/go-shiori/go-epub/blob/master/LICENSE)

--- a/epub.go
+++ b/epub.go
@@ -587,6 +587,11 @@ func (e *Epub) EmbedImages() {
 		for _, match := range imageTagMatches {
 			imageURL := match[1]
 			if !strings.HasPrefix(imageURL, "data:image/") {
+				// Check if the image URL already exists in the map
+				if _, exists := images[imageURL]; exists {
+					continue
+				}
+
 				images[imageURL] = match[0]
 				filePath, err := e.AddImage(string(imageURL), "")
 				if err != nil {

--- a/epub.go
+++ b/epub.go
@@ -1,7 +1,6 @@
 /*
 Package epub generates valid EPUB 3.0 files with additional EPUB 2.0 table of
-contents (as seen here: https://github.com/bmaupin/epub-samples) for maximum
-compatibility.
+contents for maximum compatibility.
 
 Basic usage:
 

--- a/epub.go
+++ b/epub.go
@@ -587,7 +587,7 @@ func (e *Epub) EmbedImages() {
 		for _, match := range imageTagMatches {
 			imageURL := match[1]
 			if !strings.HasPrefix(imageURL, "data:image/") {
-				// Check if the image URL already exists in the map
+				// Check if the image exists somewhere else in the document, to avoid processing it several times
 				if _, exists := images[imageURL]; exists {
 					continue
 				}
@@ -595,6 +595,9 @@ func (e *Epub) EmbedImages() {
 				images[imageURL] = match[1]
 
 				// organize img tags first one always be src and other data-src
+				// at least one src that point to the file inside epub
+				// no dupolicate src that point to the same file
+				// you can read more details https://github.com/go-shiori/go-epub/pull/3#issuecomment-1703777716
 				// Replace all "data-src=" with "src="
 				match[0] = strings.ReplaceAll(match[0], " data-src=", " src=")
 

--- a/epub.go
+++ b/epub.go
@@ -607,7 +607,6 @@ func (e *Epub) EmbedImages() {
 					continue
 				}
 				newImgTag := strings.ReplaceAll(match[0], imageURL, filePath)
-				//e.sections[i].xhtml.xml.Body.XML = strings.ReplaceAll(section.xhtml.xml.Body.XML, match[0], replaceSrcAttribute(match[0], filePath))
 				e.sections[i].xhtml.xml.Body.XML = strings.ReplaceAll(section.xhtml.xml.Body.XML, originalImgTag, newImgTag)
 			}
 		}

--- a/epub.go
+++ b/epub.go
@@ -5,7 +5,11 @@ contents for maximum compatibility.
 Basic usage:
 
 	// Create a new EPUB
-	e := epub.NewEpub("My title")
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		log.Println(err)
+	}
+
 
 	// Set the author
 	e.SetAuthor("Hingle McCringleberry")
@@ -155,7 +159,8 @@ type epubSection struct {
 }
 
 // NewEpub returns a new Epub.
-func NewEpub(title string) *Epub {
+func NewEpub(title string) (*Epub, error) {
+	var err error
 	e := &Epub{}
 	e.cover = &epubCover{
 		cssFilename:   "",
@@ -169,14 +174,20 @@ func NewEpub(title string) *Epub {
 	e.images = make(map[string]string)
 	e.videos = make(map[string]string)
 	e.audios = make(map[string]string)
-	e.pkg = newPackage()
-	e.toc = newToc()
+	e.pkg, err = newPackage()
+	if err != nil {
+		return nil, fmt.Errorf("can't create NewEpub: %w", err)
+	}
+	e.toc, err = newToc()
+	if err != nil {
+		return nil, fmt.Errorf("can't create NewEpub: %w", err)
+	}
 	// Set minimal required attributes
 	e.SetIdentifier(urnUUIDPrefix + uuid.Must(uuid.NewV4()).String())
 	e.SetLang(defaultEpubLang)
 	e.SetTitle(title)
 
-	return e
+	return e, nil
 }
 
 // AddCSS adds a CSS file to the EPUB and returns a relative path to the CSS
@@ -370,7 +381,11 @@ func (e *Epub) addSection(parentFilename string, body string, sectionTitle strin
 		return "", &ParentDoesNotExistError{Filename: parentFilename}
 	}
 
-	x := newXhtml(body)
+	x, err := newXhtml(body)
+	if err != nil {
+		//return internalFilename, errors.Wrap(err, "can't add section we cant create xhtml")
+		return internalFilename, fmt.Errorf("can't add section we cant create xhtml: %w", err)
+	}
 	x.setTitle(sectionTitle)
 	x.setXmlnsEpub(xmlnsEpub)
 
@@ -439,7 +454,7 @@ func (e *Epub) SetAuthor(author string) {
 // The internal path to an already-added CSS file (as returned by AddCSS) to be
 // used for the cover is optional. If the CSS path isn't provided, default CSS
 // will be used.
-func (e *Epub) SetCover(internalImagePath string, internalCSSPath string) {
+func (e *Epub) SetCover(internalImagePath string, internalCSSPath string) error {
 	e.Lock()
 	defer e.Unlock()
 	// If a cover already exists
@@ -483,12 +498,12 @@ func (e *Epub) SetCover(internalImagePath string, internalCSSPath string) {
 			internalCSSPath, err = e.addCSS(e.cover.cssTempFile, coverCSSFilename)
 			if _, ok := err.(*FilenameAlreadyUsedError); ok {
 				// This shouldn't cause an error
-				panic(fmt.Sprintf("Error adding default cover CSS file: %s", err))
+				return fmt.Errorf("Error adding default cover CSS file: %w", err)
 			}
 		}
 		if err != nil {
 			if _, ok := err.(*FilenameAlreadyUsedError); !ok {
-				panic(fmt.Sprintf("DEBUG %+v", err))
+				return err
 			}
 		}
 	}
@@ -503,10 +518,11 @@ func (e *Epub) SetCover(internalImagePath string, internalCSSPath string) {
 		coverPath, err = e.addSection("", coverBody, "", "", internalCSSPath)
 		if _, ok := err.(*FilenameAlreadyUsedError); ok {
 			// This shouldn't cause an error since we're not specifying a filename
-			panic(fmt.Sprintf("Error adding default cover XHTML file: %s", err))
+			return fmt.Errorf("Error adding default cover XHTML file: %w", err)
 		}
 	}
 	e.cover.xhtmlFilename = filepath.Base(coverPath)
+	return nil
 }
 
 // SetIdentifier sets the unique identifier of the EPUB, such as a UUID, DOI,

--- a/epub.go
+++ b/epub.go
@@ -42,9 +42,7 @@ import (
 	"strings"
 	"sync"
 
-	// TODO: Eventually this should include the major version (e.g. github.com/gofrs/uuid/v3) but that would break
-	// compatibility with Go < 1.9 (https://github.com/golang/go/wiki/Modules#semantic-import-versioning)
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/vincent-petithory/dataurl"
 )
 

--- a/epub.go
+++ b/epub.go
@@ -17,7 +17,10 @@ Basic usage:
 	// Add a section
 	section1Body := `<h1>Section 1</h1>
 	<p>This is a paragraph.</p>`
-	e.AddSection(section1Body, "Section 1", "", "")
+	e, err := e.AddSection(section1Body, "Section 1", "", "")
+	if err != nil {
+		log.Println(err)
+	}
 
 	// Write the EPUB
 	err = e.Write("My EPUB.epub")

--- a/epub_test.go
+++ b/epub_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmaupin/go-epub/internal/storage"
+	"github.com/go-shiori/go-epub/internal/storage"
 	"github.com/gofrs/uuid"
 )
 

--- a/epub_test.go
+++ b/epub_test.go
@@ -863,12 +863,20 @@ func TestManifestItems(t *testing.T) {
 	defer server.Close()
 
 	testImageFromURLSource := server.URL + "/gophercolor16x16.png"
+	testManifestItems := []string{
+		`id="id5857b58e-9d4f-5b23-ad10-d2644bb66023" href="images/filename with space.png" media-type="image/png"></item>`,
+		`id="id72c19376-e8fb-584c-9dbe-abc447874747" href="images/testfromfile.png" media-type="image/png"></item>`,
+		`id="id971cabb4-8f27-530a-b2fc-24044798f8a7" href="images/image0005.png" media-type="image/png"></item>`,
+		`id="ide5dc5e63-8586-5ff2-94d9-037b0543ac24" href="images/gophercolor16x16.png" media-type="image/png"></item>`,
+		`id="idfbc147f0-b6fd-5f0f-9d96-69f1c80e2ec6" href="images/01filenametest.png" media-type="image/png"></item>`,
+		`id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"></item>`,
+	}
 
 	e, err := NewEpub(testEpubTitle)
 	if err != nil {
 		t.Error(err)
 	}
-  _, err = e.AddImage(testImageFromFileSource, testImageFromFileFilename)
+	_, err = e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	if err != nil {
 		t.Error(err)
 	}
@@ -936,6 +944,17 @@ func TestManifestItems(t *testing.T) {
 	manifestContent := strings.Join(pkgFileManifestItems[:], "\n")
 	if !strings.Contains(manifestContent, line) {
 		t.Errorf("can't find nav: %s", manifestContent)
+	}
+
+	// Compare the slices by converting them to strings
+	if strings.Join(pkgFileManifestItems[:], ",") != strings.Join(testManifestItems[:], ",") {
+		t.Errorf(
+			"Package file manifest items don't match\n"+
+				"Got: \n%s\n\n"+
+				"Expected: \n%s\n",
+			strings.Join(pkgFileManifestItems[:], "\n"),
+			strings.Join(testManifestItems[:], "\n"))
+
 	}
 
 	cleanup(testEpubFilename, tempDir)

--- a/epub_test.go
+++ b/epub_test.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/go-shiori/go-epub/internal/storage"
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v5"
 )
 
 const (

--- a/epub_test.go
+++ b/epub_test.go
@@ -850,9 +850,10 @@ func TestManifestItems(t *testing.T) {
 
 	testImageFromURLSource := server.URL + "/gophercolor16x16.png"
 	testManifestItems := []string{
+		`id="id18a490af-f1fc-5ee4-a449-5c80f646a659" href="images/image0003.png" media-type="image/png"></item>`,
 		`id="id5857b58e-9d4f-5b23-ad10-d2644bb66023" href="images/filename with space.png" media-type="image/png"></item>`,
 		`id="id72c19376-e8fb-584c-9dbe-abc447874747" href="images/testfromfile.png" media-type="image/png"></item>`,
-		`id="id971cabb4-8f27-530a-b2fc-24044798f8a7" href="images/image0005.png" media-type="image/png"></item>`,
+		`id="ide10ba9f7-2ca1-5db1-8b0c-cbdf809c8372" href="images/image0006.png" media-type="image/png"></item>`,
 		`id="ide5dc5e63-8586-5ff2-94d9-037b0543ac24" href="images/gophercolor16x16.png" media-type="image/png"></item>`,
 		`id="idfbc147f0-b6fd-5f0f-9d96-69f1c80e2ec6" href="images/01filenametest.png" media-type="image/png"></item>`,
 		`id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"></item>`,
@@ -866,6 +867,11 @@ func TestManifestItems(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	_, err = e.AddImage(testImageFromFileSource, "")
+	if err != nil {
+		t.Error(err)
+	}
+
 	_, err = e.AddImage(testImageFromFileSource, "")
 	if err != nil {
 		t.Error(err)

--- a/epub_test.go
+++ b/epub_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -834,6 +835,19 @@ func TestSetCover(t *testing.T) {
 	cleanup(testEpubFilename, tempDir)
 }
 
+func extractManifestIds(manifestContent string) ([]string, error) {
+	re := regexp.MustCompile(`id([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`)
+	matches := re.FindAllStringSubmatch(manifestContent, -1)
+	if matches == nil {
+		return nil, fmt.Errorf("no manifest item ids found")
+	}
+	var ids []string
+	for _, match := range matches {
+		ids = append(ids, "id"+match[1])
+	}
+	return ids, nil
+}
+
 func TestManifestItems(t *testing.T) {
 	fs := http.FileServer(http.Dir("./testdata/"))
 
@@ -842,19 +856,7 @@ func TestManifestItems(t *testing.T) {
 	defer server.Close()
 
 	testImageFromURLSource := server.URL + "/gophercolor16x16.png"
-	testManifestItems := []string{`id="filenamewithspace.png" href="images/filename with space.png" media-type="image/png"></item>`,
-		`id="gophercolor16x16.png" href="images/gophercolor16x16.png" media-type="image/png"></item>`,
-		`id="id01filenametest.png" href="images/01filenametest.png" media-type="image/png"></item>`,
-		`id="image0005.png" href="images/image0005.png" media-type="image/png"></item>`,
-		`id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"></item>`,
-		`id="testfromfile.png" href="images/testfromfile.png" media-type="image/png"></item>`,
-	}
-
-	e, err := NewEpub(testEpubTitle)
-	if err != nil {
-		t.Error(err)
-	}
-
+	e, _ := NewEpub(testEpubTitle)
 	e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	e.AddImage(testImageFromFileSource, "")
 	// In particular, we want to test these next two, which will be modified by fixXMLId()
@@ -869,8 +871,29 @@ func TestManifestItems(t *testing.T) {
 		t.Errorf("Unexpected error reading package file: %s", err)
 	}
 
+	expectedIds := []string{
+		"filenamewithspace.png",
+		"gophercolor16x16.png",
+		"id01filenametest.png",
+		"image0005.png",
+		"testfromfile.png",
+	}
+
 	// Get just the manifest portion of the package file
 	manifestContentFromFile := string(pkgFileContent)[strings.Index(string(pkgFileContent), "<manifest>"):strings.Index(string(pkgFileContent), "</manifest>")]
+	ids, err := extractManifestIds(manifestContentFromFile)
+	if err != nil {
+		t.Errorf("Unexpected error extracting manifest item ids: %s", err)
+	}
+	if len(ids) != len(expectedIds) {
+		t.Errorf("Unexpected number of manifest item ids: got %d, expected %d", len(ids), len(expectedIds))
+	}
+	for _, id := range ids {
+		if !strings.HasPrefix(id, "id") {
+			t.Errorf("Manifest item id %q does not start with \"id\"", id)
+		}
+	}
+
 	// Convert the manifest portion of the package file to a slice
 	pkgFileManifestItems := strings.Split(manifestContentFromFile, "<item")
 	// Drop the <manifest> and </manifest>
@@ -882,14 +905,10 @@ func TestManifestItems(t *testing.T) {
 	// Sort the manifest items from the package file (they will be in a random order)
 	sort.Strings(pkgFileManifestItems)
 
-	// Compare the slices by converting them to strings
-	if strings.Join(pkgFileManifestItems[:], ",") != strings.Join(testManifestItems[:], ",") {
-		t.Errorf(
-			"Package file manifest items don't match\n"+
-				"Got: \n%s\n\n"+
-				"Expected: \n%s\n",
-			strings.Join(pkgFileManifestItems[:], "\n"),
-			strings.Join(testManifestItems[:], "\n"))
+	line := `id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"></item>`
+	manifestContent := strings.Join(pkgFileManifestItems[:], "\n")
+	if !strings.Contains(manifestContent, line) {
+		t.Errorf("can't find nav: %s", manifestContent)
 	}
 
 	cleanup(testEpubFilename, tempDir)

--- a/epub_test.go
+++ b/epub_test.go
@@ -109,7 +109,10 @@ const (
 )
 
 func TestEpubWrite(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
 
 	tempDir := writeAndExtractEpub(t, e, testEpubFilename)
 
@@ -162,7 +165,11 @@ func TestEpubWrite(t *testing.T) {
 }
 
 func TestAddCSS(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testCSS1Path, err := e.AddCSS(testCoverCSSSource, testCoverCSSFilename)
 	if err != nil {
 		t.Errorf("Error adding CSS: %s", err)
@@ -234,7 +241,11 @@ func TestAddCSS(t *testing.T) {
 }
 
 func TestAddFont(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testFontFromFilePath, err := e.AddFont(testFontFromFileSource, "")
 	if err != nil {
 		t.Errorf("Error adding font: %s", err)
@@ -267,7 +278,11 @@ func TestAddImage(t *testing.T) {
 	defer server.Close()
 
 	testImageFromURLSource := server.URL + "/gophercolor16x16.png"
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testImageFromFilePath, err := e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	if err != nil {
 		t.Errorf("Error adding image: %s", err)
@@ -323,7 +338,11 @@ func TestAddVideo(t *testing.T) {
 
 	testVideoFromURLSource := server.URL + "/sample_640x360.mp4"
 
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testVideoFromFilePath, err := e.AddVideo(testVideoFromFileSource, testVideoFromFileFilename)
 	if err != nil {
 		t.Errorf("Error adding video: %s", err)
@@ -373,7 +392,11 @@ func TestAddVideo(t *testing.T) {
 }
 
 func TestAddAudio(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testAudioFromFilePath, err := e.AddAudio(testAudioFromFileSource, testAudioFromFileFilename)
 	if err != nil {
 		t.Errorf("Error adding audio: %s", err)
@@ -430,7 +453,11 @@ func TestAddAudio(t *testing.T) {
 }
 
 func TestAddSection(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testSection1Path, err := e.AddSection(testSectionBody, testSectionTitle, testSectionFilename, "")
 	if err != nil {
 		t.Errorf("Error adding section: %s", err)
@@ -476,7 +503,11 @@ func TestAddSection(t *testing.T) {
 }
 
 func TestAddSubSection(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testSection1Path, err := e.AddSection(testSectionBody, testSectionTitle, testSectionFilename, "")
 	if err != nil {
 		t.Errorf("Error adding section: %s", err)
@@ -522,7 +553,11 @@ func TestAddSubSection(t *testing.T) {
 }
 
 func TestEpubAuthor(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	e.SetAuthor(testEpubAuthor)
 
 	if e.Author() != testEpubAuthor {
@@ -555,7 +590,11 @@ func TestEpubAuthor(t *testing.T) {
 }
 
 func TestEpubLang(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	e.SetLang(testEpubLang)
 
 	if e.Lang() != testEpubLang {
@@ -588,7 +627,11 @@ func TestEpubLang(t *testing.T) {
 }
 
 func TestEpubPpd(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	e.SetPpd(testEpubPpd)
 
 	if e.Ppd() != testEpubPpd {
@@ -622,7 +665,11 @@ func TestEpubPpd(t *testing.T) {
 
 func TestEpubTitle(t *testing.T) {
 	// First, test the title we provide when creating the epub
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	if e.Title() != testEpubTitle {
 		t.Errorf(
 			"Title doesn't match\n"+
@@ -684,7 +731,11 @@ func TestEpubTitle(t *testing.T) {
 }
 
 func TestEpubDescription(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	e.SetDescription(testEpubDescription)
 
 	if e.Description() != testEpubDescription {
@@ -717,7 +768,11 @@ func TestEpubDescription(t *testing.T) {
 }
 
 func TestEpubIdentifier(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	e.SetIdentifier(testEpubIdentifier)
 
 	if e.Identifier() != testEpubIdentifier {
@@ -750,7 +805,11 @@ func TestEpubIdentifier(t *testing.T) {
 }
 
 func TestSetCover(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testImagePath, _ := e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	testCSSPath, _ := e.AddCSS(testCoverCSSSource, testCoverCSSFilename)
 	e.SetCover(testImagePath, testCSSPath)
@@ -791,7 +850,11 @@ func TestManifestItems(t *testing.T) {
 		`id="testfromfile.png" href="images/testfromfile.png" media-type="image/png"></item>`,
 	}
 
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	e.AddImage(testImageFromFileSource, testImageFromFileFilename)
 	e.AddImage(testImageFromFileSource, "")
 	// In particular, we want to test these next two, which will be modified by fixXMLId()
@@ -833,9 +896,12 @@ func TestManifestItems(t *testing.T) {
 }
 
 func TestFilenameAlreadyUsedError(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
 
-	_, err := e.AddCSS(testCoverCSSSource, testCoverCSSFilename)
+	_, err = e.AddCSS(testCoverCSSSource, testCoverCSSFilename)
 	if err != nil {
 		t.Errorf("Error adding CSS: %s", err)
 	}
@@ -847,18 +913,24 @@ func TestFilenameAlreadyUsedError(t *testing.T) {
 }
 
 func TestFileRetrievalError(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
 
-	_, err := e.AddCSS("/sbin/thisShouldFail", testCoverCSSFilename)
+	_, err = e.AddCSS("/sbin/thisShouldFail", testCoverCSSFilename)
 	if _, ok := err.(*FileRetrievalError); !ok {
 		t.Errorf("Expected error FileRetrievalError not returned. Returned instead: %+v", err)
 	}
 }
 
 func TestUnableToCreateEpubError(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
 
-	err := e.Write("/sbin/thisShouldFail")
+	err = e.Write("/sbin/thisShouldFail")
 	if _, ok := err.(*UnableToCreateEpubError); !ok {
 		t.Errorf("Expected error UnableToCreateEpubError not returned. Returned instead: %+v", err)
 	}
@@ -877,7 +949,11 @@ func TestEmbedImage(t *testing.T) {
 	testSectionBodyWithImageExpect := `    <h1>Section 1</h1>
 	<p>This is a paragraph.</p>
 	<p><img src="../images/gophercolor16x16.png" loading="lazy"/></p>`
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testSection1Path, err := e.AddSection(testSectionBody, testSectionTitle, testSectionFilename, "")
 	if err != nil {
 		t.Errorf("Error adding section: %s", err)
@@ -951,7 +1027,11 @@ func testEpubValidity(t testing.TB) {
 	testAudioFromURLSource := server.URL + "/sample_audio.wav"
 	testImageFromURLSource := server.URL + "/gophercolor16x16.png"
 	testVideoFromURLSource := server.URL + "/sample_640x360.mp4"
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
+
 	testCoverCSSPath, _ := e.AddCSS(testCoverCSSSource, testCoverCSSFilename)
 	e.AddCSS(testCoverCSSSource, "")
 	testSectionPath, _ := e.AddSection(testSectionBody, testSectionTitle, testSectionFilename, testCoverCSSPath)
@@ -1045,6 +1125,7 @@ func trimAllSpace(s string) string {
 
 // UnzipFile unzips a file located at sourceFilePath to the provided destination directory
 func unzipFile(sourceFilePath string, destDirPath string) error {
+	var t *testing.T
 	// First, make sure the destination exists and is a directory
 	f, err := filesystem.Open(destDirPath)
 	if err != nil {
@@ -1065,7 +1146,7 @@ func unzipFile(sourceFilePath string, destDirPath string) error {
 	}
 	defer func() {
 		if err := r.Close(); err != nil {
-			panic(err)
+			t.Error(err)
 		}
 	}()
 
@@ -1077,7 +1158,7 @@ func unzipFile(sourceFilePath string, destDirPath string) error {
 		}
 		defer func() {
 			if err := rc.Close(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 		}()
 
@@ -1097,7 +1178,7 @@ func unzipFile(sourceFilePath string, destDirPath string) error {
 		}
 		defer func() {
 			if err := w.Close(); err != nil {
-				panic(err)
+				t.Error(err)
 			}
 		}()
 

--- a/example_test.go
+++ b/example_test.go
@@ -34,7 +34,11 @@ func ExampleEpub_AddCSS() {
 	// Use the CSS in a section
 	sectionBody := `    <h1>Section 1</h1>
 	<p>This is a paragraph.</p>`
-	e.AddSection(sectionBody, "Section 1", "", css1Path)
+	_, err = e.AddSection(sectionBody, "Section 1", "", css1Path)
+	if err != nil {
+		log.Println(err)
+		return
+	}
 
 	fmt.Println(css1Path)
 	fmt.Println(css2Path)
@@ -181,11 +185,17 @@ func ExampleEpub_SetCover() {
 
 	// Set the cover. The CSS file is optional
 	coverImagePath, _ := e.AddImage("testdata/gophercolor16x16.png", "cover.png")
-	e.SetCover(coverImagePath, "")
+	err = e.SetCover(coverImagePath, "")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Update the cover using custom CSS
 	coverCSSPath, _ := e.AddCSS("testdata/cover.css", "")
-	e.SetCover(coverImagePath, coverCSSPath)
+	err = e.SetCover(coverImagePath, coverCSSPath)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func ExampleEpub_SetIdentifier() {

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/bmaupin/go-epub"
+	"github.com/go-shiori/go-epub"
 )
 
 func ExampleEpub_AddCSS() {

--- a/example_test.go
+++ b/example_test.go
@@ -5,23 +5,30 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	"github.com/go-shiori/go-epub"
 )
 
 func ExampleEpub_AddCSS() {
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Add CSS
 	css1Path, err := e.AddCSS("testdata/cover.css", "epub.css")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	// The filename is optional
 	css2Path, err := e.AddCSS("testdata/cover.css", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return
 	}
 
 	// Use the CSS in a section
@@ -38,18 +45,22 @@ func ExampleEpub_AddCSS() {
 }
 
 func ExampleEpub_AddFont() {
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Add a font from a local file
 	font1Path, err := e.AddFont("testdata/redacted-script-regular.ttf", "font.ttf")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	// The filename is optional
 	font2Path, err := e.AddFont("testdata/redacted-script-regular.ttf", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	fmt.Println(font1Path)
@@ -69,18 +80,22 @@ func ExampleEpub_AddImage() {
 
 	testImageFromURLSource := server.URL + "/gophercolor16x16.png"
 
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Add an image from a local file
 	img1Path, err := e.AddImage("testdata/gophercolor16x16.png", "go-gopher.png")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	// Add an image from a URL. The filename is optional
 	img2Path, err := e.AddImage(testImageFromURLSource, "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	fmt.Println(img1Path)
@@ -92,14 +107,18 @@ func ExampleEpub_AddImage() {
 }
 
 func ExampleEpub_AddSection() {
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Add a section. The CSS path is optional
 	section1Body := `    <h1>Section 1</h1>
 	<p>This is a paragraph.</p>`
 	section1Path, err := e.AddSection(section1Body, "Section 1", "firstsection.xhtml", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	// Link to the first section
@@ -109,7 +128,7 @@ func ExampleEpub_AddSection() {
 	// The title and filename are also optional
 	section2Path, err := e.AddSection(section2Body, "", "", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	fmt.Println(section1Path)
@@ -121,14 +140,18 @@ func ExampleEpub_AddSection() {
 }
 
 func ExampleEpub_AddSubSection() {
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Add a section. The CSS path is optional
 	section1Body := `    <h1>Section 1</h1>
 	<p>This is a paragraph.</p>`
 	section1Path, err := e.AddSection(section1Body, "Section 1", "firstsection.xhtml", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	// Link to the first section
@@ -138,7 +161,7 @@ func ExampleEpub_AddSubSection() {
 	// The title and filename are also optional
 	section2Path, err := e.AddSubSection(section1Path, section2Body, "", "", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	fmt.Println(section1Path)
@@ -150,7 +173,11 @@ func ExampleEpub_AddSubSection() {
 }
 
 func ExampleEpub_SetCover() {
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Set the cover. The CSS file is optional
 	coverImagePath, _ := e.AddImage("testdata/gophercolor16x16.png", "cover.png")
@@ -162,7 +189,11 @@ func ExampleEpub_SetCover() {
 }
 
 func ExampleEpub_SetIdentifier() {
-	e := epub.NewEpub("My title")
+	var t *testing.T
+	e, err := epub.NewEpub("My title")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Set the identifier to a UUID
 	e.SetIdentifier("urn:uuid:a1b0d67e-2e81-4df5-9e67-a64cbe366809")

--- a/fetchmedia.go
+++ b/fetchmedia.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -156,7 +155,7 @@ func (g grabber) dataURLHandler(mediaSource string, onlyCheck bool) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(bytes.NewReader(data.Data)), nil
+	return io.NopCloser(bytes.NewReader(data.Data)), nil
 }
 
 type fetchError []error

--- a/fetchmedia.go
+++ b/fetchmedia.go
@@ -107,7 +107,7 @@ func (g grabber) fetchMedia(mediaSource, mediaFolderPath, mediaFilename string) 
 	defer r.Close()
 	mime, err := mimetype.DetectReader(r)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("unable to detect media type: %w", err)
 	}
 
 	// Is it CSS?

--- a/fetchmedia_test.go
+++ b/fetchmedia_test.go
@@ -36,11 +36,17 @@ AAAAAAAAAAAAAA==`, "\n", "", -1)
 
 func Test_fetchMedia(t *testing.T) {
 	t.Run("LocalFS", func(t *testing.T) {
-		Use(OsFS)
+		err := Use(OsFS)
+		if err != nil {
+			t.Error(err)
+		}
 		testFetchMedia(t)
 	})
 	t.Run("MemoryFS", func(t *testing.T) {
-		Use(MemoryFS)
+		err := Use(MemoryFS)
+		if err != nil {
+			t.Error(err)
+		}
 		testFetchMedia(t)
 	})
 }
@@ -54,7 +60,10 @@ func testFetchMedia(t *testing.T) {
 			t.Fatal("cannot open testdata")
 		}
 		defer data.Close()
-		io.Copy(w, data)
+		_, err = io.Copy(w, data)
+		if err != nil {
+			t.Fatal("cannot open testdata")
+		}
 	}))
 	mux.HandleFunc("/test.css", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "body{}")

--- a/fs.go
+++ b/fs.go
@@ -1,6 +1,7 @@
 package epub
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-shiori/go-epub/internal/storage"
@@ -23,7 +24,7 @@ const (
 
 // Use s as default storage/ This is typically used in an init function.
 // Default to local filesystem
-func Use(s FSType) {
+func Use(s FSType) error {
 	switch s {
 	case OsFS:
 		filesystem = osfs.NewOSFS(os.TempDir())
@@ -31,6 +32,7 @@ func Use(s FSType) {
 		//TODO
 		filesystem = memory.NewMemory()
 	default:
-		panic("unexpected FSType")
+		return fmt.Errorf("unexpected FSType")
 	}
+	return nil
 }

--- a/fs.go
+++ b/fs.go
@@ -3,9 +3,9 @@ package epub
 import (
 	"os"
 
-	"github.com/bmaupin/go-epub/internal/storage"
-	"github.com/bmaupin/go-epub/internal/storage/memory"
-	"github.com/bmaupin/go-epub/internal/storage/osfs"
+	"github.com/go-shiori/go-epub/internal/storage"
+	"github.com/go-shiori/go-epub/internal/storage/memory"
+	"github.com/go-shiori/go-epub/internal/storage/osfs"
 )
 
 type FSType int

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/gofrs/uuid/v5 v5.0.0
 	github.com/vincent-petithory/dataurl v1.0.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.2
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/gofrs/uuid/v5 v5.0.0
 	github.com/vincent-petithory/dataurl v1.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,4 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0
 )
 
-require (
-	github.com/google/uuid v1.3.1 // indirect
-	golang.org/x/net v0.13.0 // indirect
-)
+require golang.org/x/net v0.13.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bmaupin/go-epub
+module github.com/go-shiori/go-epub
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	github.com/vincent-petithory/dataurl v1.0.0
 )
 
-require golang.org/x/net v0.13.0 // indirect
+require (
+	github.com/google/uuid v1.3.1 // indirect
+	golang.org/x/net v0.13.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
+github.com/gofrs/uuid/v5 v5.0.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
 github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
 github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
 github.com/gofrs/uuid/v5 v5.0.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=

--- a/internal/storage/memory/fs.go
+++ b/internal/storage/memory/fs.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bmaupin/go-epub/internal/storage"
+	"github.com/go-shiori/go-epub/internal/storage"
 )
 
 type Memory struct {

--- a/internal/storage/memory/fs_test.go
+++ b/internal/storage/memory/fs_test.go
@@ -1,7 +1,7 @@
 package memory
 
 import (
-	"io/ioutil"
+	"io"
 	"path"
 	"path/filepath"
 	"testing"
@@ -33,13 +33,16 @@ func TestMemory_Mkdir(t *testing.T) {
 func TestMemory_WriteFile(t *testing.T) {
 	fs := NewMemory()
 
-	fs.WriteFile("test", []byte{}, 0666)
+	err := fs.WriteFile("test", []byte{}, 0666)
+	if err != nil {
+		t.Fail()
+	}
 	file, _ := fs.Open("test")
 	stat, _ := file.Stat()
 	if !stat.Mode().IsRegular() {
 		t.Fail()
 	}
-	err := fs.WriteFile("./..", []byte{}, 0666)
+	err = fs.WriteFile("./..", []byte{}, 0666)
 	if err == nil {
 		t.Fail()
 	}
@@ -48,13 +51,16 @@ func TestMemory_WriteFile(t *testing.T) {
 func TestMemory_Create(t *testing.T) {
 	fs := NewMemory()
 
-	fs.Create("test")
+	_, err := fs.Create("test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	file, _ := fs.Open("test")
 	stat, _ := file.Stat()
 	if !stat.Mode().IsRegular() {
 		t.Fail()
 	}
-	_, err := fs.Create("./..")
+	_, err = fs.Create("./..")
 	if err == nil {
 		t.Fail()
 	}
@@ -75,7 +81,7 @@ func TestMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open error: %v", err)
 	}
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatalf("readall error: %v", err)
 	}

--- a/internal/storage/osfs/fs.go
+++ b/internal/storage/osfs/fs.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bmaupin/go-epub/internal/storage"
+	"github.com/go-shiori/go-epub/internal/storage"
 )
 
 type OSFS struct {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -5,7 +5,6 @@ package storage
 import (
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -35,7 +34,7 @@ func ReadFile(fs Storage, name string) ([]byte, error) {
 		return nil, err
 	}
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 func MkdirAll(fs Storage, dir string, perm fs.FileMode) error {
 	list := make([]string, 0)

--- a/perf_test.go
+++ b/perf_test.go
@@ -27,7 +27,10 @@ func BenchmarkAddImage_http(b *testing.B) {
 	}))
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
-	e := NewEpub("test")
+	e, err := NewEpub("test")
+	if err != nil {
+		b.Error(err)
+	}
 	for i := 0; i < b.N; i++ {
 		_, err := e.AddImage(ts.URL+"/image.png", "")
 		if err != nil {
@@ -36,7 +39,10 @@ func BenchmarkAddImage_http(b *testing.B) {
 	}
 }
 func BenchmarkAddImage_file(b *testing.B) {
-	e := NewEpub("test")
+	e, err := NewEpub("test")
+	if err != nil {
+		b.Error(err)
+	}
 	for i := 0; i < b.N; i++ {
 		_, err := e.AddImage("testdata/gophercolor16x16.png", "")
 		if err != nil {

--- a/perf_test.go
+++ b/perf_test.go
@@ -20,7 +20,11 @@ func BenchmarkAddImage_http(b *testing.B) {
 				b.Fatal("cannot open testdata")
 			}
 			defer data.Close()
-			io.Copy(w, data)
+			_, err = io.Copy(w, data)
+			if err != nil {
+				b.Fatal("cannot copy content")
+			}
+
 		case "HEAD":
 			w.WriteHeader(http.StatusOK)
 		}

--- a/pkg.go
+++ b/pkg.go
@@ -37,7 +37,6 @@ const (
 // pkg implements the package document file (package.opf), which contains
 // metadata about the EPUB (title, author, etc) as well as a list of files the
 // EPUB contains.
-//
 // Spec: http://www.idpf.org/epub/301/spec/epub-publications.html
 type pkg struct {
 	xml          *pkgRoot
@@ -124,7 +123,7 @@ type pkgSpine struct {
 }
 
 // Constructor for pkg
-func newPackage() *pkg {
+func newPackage() (*pkg, error) {
 	p := &pkg{
 		xml: &pkgRoot{
 			Metadata: pkgMetadata{
@@ -138,16 +137,10 @@ func newPackage() *pkg {
 
 	err := xml.Unmarshal([]byte(pkgFileTemplate), &p.xml)
 	if err != nil {
-		panic(fmt.Sprintf(
-			"Error unmarshalling package file XML: %s\n"+
-				"\tp.xml=%#v\n"+
-				"\tpkgFileTemplate=%s",
-			err,
-			*p.xml,
-			pkgFileTemplate))
+		return nil, fmt.Errorf("Error unmarshalling package file XML: %w\n"+"\tp.xml=%#v\n"+"\tpkgFileTemplate=%s", err, p.xml, pkgFileTemplate)
 	}
 
-	return p
+	return p, nil
 }
 
 func (p *pkg) addToManifest(id string, href string, mediaType string, properties string) {
@@ -252,7 +245,7 @@ func updateMeta(a []pkgMeta, m *pkgMeta) []pkgMeta {
 }
 
 // Write the package file to the temporary directory
-func (p *pkg) write(tempDir string) {
+func (p *pkg) write(tempDir string) error {
 	now := time.Now().UTC().Format("2006-01-02T15:04:05Z")
 	p.setModified(now)
 
@@ -260,11 +253,7 @@ func (p *pkg) write(tempDir string) {
 
 	output, err := xml.MarshalIndent(p.xml, "", "  ")
 	if err != nil {
-		panic(fmt.Sprintf(
-			"Error marshalling XML for package file: %s\n"+
-				"\tXML=%#v",
-			err,
-			p.xml))
+		return fmt.Errorf("Error unmarshalling XML for package file: %w\n"+"\tp.xml=%#v", err, p.xml)
 	}
 	// Add the xml header to the output
 	pkgFileContent := append([]byte(xml.Header), output...)
@@ -272,6 +261,7 @@ func (p *pkg) write(tempDir string) {
 	pkgFileContent = append(pkgFileContent, "\n"...)
 
 	if err := filesystem.WriteFile(pkgFilePath, []byte(pkgFileContent), filePermissions); err != nil {
-		panic(fmt.Sprintf("Error writing package file: %s", err))
+		return fmt.Errorf("Error writing package file: %w", err)
 	}
+	return nil
 }

--- a/pkg.go
+++ b/pkg.go
@@ -38,7 +38,6 @@ const (
 // metadata about the EPUB (title, author, etc) as well as a list of files the
 // EPUB contains.
 //
-// Sample: https://github.com/bmaupin/epub-samples/blob/master/minimal-v3plus2/EPUB/package.opf
 // Spec: http://www.idpf.org/epub/301/spec/epub-publications.html
 type pkg struct {
 	xml          *pkgRoot
@@ -73,8 +72,9 @@ type pkgIdentifier struct {
 
 // <item> elements, one per each file stored in the EPUB
 // Ex: <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav" />
-//     <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-//     <item id="section0001.xhtml" href="xhtml/section0001.xhtml" media-type="application/xhtml+xml" />
+//
+//	<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+//	<item id="section0001.xhtml" href="xhtml/section0001.xhtml" media-type="application/xhtml+xml" />
 type pkgItem struct {
 	ID         string `xml:"id,attr"`
 	Href       string `xml:"href,attr"`
@@ -91,7 +91,8 @@ type pkgItemref struct {
 // The <meta> element, which contains modified date, role of the creator (e.g.
 // author), etc
 // Ex: <meta refines="#creator" property="role" scheme="marc:relators" id="role">aut</meta>
-//     <meta property="dcterms:modified">2011-01-01T12:00:00Z</meta>
+//
+//	<meta property="dcterms:modified">2011-01-01T12:00:00Z</meta>
 type pkgMeta struct {
 	Refines  string `xml:"refines,attr,omitempty"`
 	Property string `xml:"property,attr,omitempty"`

--- a/toc.go
+++ b/toc.go
@@ -46,14 +46,12 @@ type toc struct {
 	// This holds the body XML for the EPUB v3 TOC file (nav.xhtml). Since this is
 	// an XHTML file, the rest of the structure is handled by the xhtml type
 	//
-	// Sample: https://github.com/bmaupin/epub-samples/blob/master/minimal-v3plus2/EPUB/nav.xhtml
 	// Spec: http://www.idpf.org/epub/301/spec/epub-contentdocs.html#sec-xhtml-nav
 	navXML *tocNavBody
 
 	// This holds the XML for the EPUB v2 TOC file (toc.ncx). This is added so the
 	// resulting EPUB v3 file will still work with devices that only support EPUB v2
 	//
-	// Sample: https://github.com/bmaupin/epub-samples/blob/master/minimal-v3plus2/EPUB/toc.ncx
 	// Spec: http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1
 	ncxXML *tocNcxRoot
 
@@ -195,7 +193,7 @@ func (t *toc) addSubSection(parent string, index int, title string, relativePath
 			Data: title,
 		},
 	}
-	if len(t.navXML.Links) > parentNavIndex  {
+	if len(t.navXML.Links) > parentNavIndex {
 		// Create a new array if none exists
 		if t.navXML.Links[parentNavIndex].Children == nil {
 			n := make([]tocNavItem, 0)

--- a/toc.go
+++ b/toc.go
@@ -104,51 +104,46 @@ type tocNcxNavPoint struct {
 }
 
 // Constructor for toc
-func newToc() *toc {
+func newToc() (*toc, error) {
 	t := &toc{}
+	var err error
 
-	t.navXML = newTocNavXML()
+	t.navXML, err = newTocNavXML()
+	if err != nil {
+		return nil, fmt.Errorf("can't create navXML: %w", err)
+	}
 
-	t.ncxXML = newTocNcxXML()
+	t.ncxXML, err = newTocNcxXML()
+	if err != nil {
+		return nil, fmt.Errorf("can't create navXML: %w", err)
+	}
 
-	return t
+	return t, nil
 }
 
 // Constructor for tocNavBody
-func newTocNavXML() *tocNavBody {
+func newTocNavXML() (*tocNavBody, error) {
 	b := &tocNavBody{
 		EpubType: tocNavEpubType,
 	}
 	err := xml.Unmarshal([]byte(tocNavBodyTemplate), &b)
 	if err != nil {
-		panic(fmt.Sprintf(
-			"Error unmarshalling tocNavBody: %s\n"+
-				"\ttocNavBody=%#v\n"+
-				"\ttocNavBodyTemplate=%s",
-			err,
-			*b,
-			tocNavBodyTemplate))
+		return nil, fmt.Errorf("Error unmarshalling tocNavBody: %w\n"+"\ttocNavBody=%#v\n"+"\ttocNavBodyTemplate=%s", err, *b, tocNavBodyTemplate)
 	}
 
-	return b
+	return b, nil
 }
 
 // Constructor for tocNcxRoot
-func newTocNcxXML() *tocNcxRoot {
+func newTocNcxXML() (*tocNcxRoot, error) {
 	n := &tocNcxRoot{}
 
 	err := xml.Unmarshal([]byte(tocNcxTemplate), &n)
 	if err != nil {
-		panic(fmt.Sprintf(
-			"Error unmarshalling tocNcxRoot: %s\n"+
-				"\ttocNcxRoot=%#v\n"+
-				"\ttocNcxTemplate=%s",
-			err,
-			*n,
-			tocNcxTemplate))
+		return nil, fmt.Errorf("Error unmarshalling tocNcxRoot: %w\n"+"\ttocNcxRoot=%#v\n"+"\ttocNcxTemplate=%s", err, *n, tocNcxTemplate)
 	}
 
-	return n
+	return n, nil
 }
 
 // Add a section to the TOC (navXML as well as ncxXML)
@@ -244,42 +239,48 @@ func (t *toc) setAuthor(author string) {
 }
 
 // Write the TOC files
-func (t *toc) write(tempDir string) {
-	t.writeNavDoc(tempDir)
-	t.writeNcxDoc(tempDir)
+func (t *toc) write(tempDir string) error {
+	err := t.writeNavDoc(tempDir)
+	if err != nil {
+		return err
+	}
+	err = t.writeNcxDoc(tempDir)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Write the the EPUB v3 TOC file (nav.xhtml) to the temporary directory
-func (t *toc) writeNavDoc(tempDir string) {
+func (t *toc) writeNavDoc(tempDir string) error {
 	navBodyContent, err := xml.MarshalIndent(t.navXML, "    ", "  ")
 	if err != nil {
-		panic(fmt.Sprintf(
-			"Error marshalling XML for EPUB v3 TOC file: %s\n"+
-				"\tXML=%#v",
-			err,
-			t.navXML))
+		return fmt.Errorf("Error marshalling XML for EPUB v3 TOC file: %w\n"+"\tXML=%#v", err, t.navXML)
 	}
 
-	n := newXhtml(string(navBodyContent))
+	n, err := newXhtml(string(navBodyContent))
+	if err != nil {
+		return fmt.Errorf("can't create xhtml for TOC file: %w", err)
+	}
 	n.setXmlnsEpub(xmlnsEpub)
 	n.setTitle(t.title)
 
 	navFilePath := filepath.Join(tempDir, contentFolderName, tocNavFilename)
-	n.write(navFilePath)
+	err = n.write(navFilePath)
+	if err != nil {
+		return fmt.Errorf("can't write TOC file: %w", err)
+	}
+	return nil
 }
 
 // Write the EPUB v2 TOC file (toc.ncx) to the temporary directory
-func (t *toc) writeNcxDoc(tempDir string) {
+func (t *toc) writeNcxDoc(tempDir string) error {
 	t.ncxXML.Title = t.title
 	t.ncxXML.Author = t.author
 
 	ncxFileContent, err := xml.MarshalIndent(t.ncxXML, "", "  ")
 	if err != nil {
-		panic(fmt.Sprintf(
-			"Error marshalling XML for EPUB v2 TOC file: %s\n"+
-				"\tXML=%#v",
-			err,
-			t.ncxXML))
+		return fmt.Errorf("Error marshalling XML for EPUB v2 TOC file: %w\n"+"+\tXML=%#v", err, t.ncxXML)
 	}
 
 	// Add the xml header to the output
@@ -289,6 +290,7 @@ func (t *toc) writeNcxDoc(tempDir string) {
 
 	ncxFilePath := filepath.Join(tempDir, contentFolderName, tocNcxFilename)
 	if err := filesystem.WriteFile(ncxFilePath, []byte(ncxFileContent), filePermissions); err != nil {
-		panic(fmt.Sprintf("Error writing EPUB v2 TOC file: %s", err))
+		return fmt.Errorf("Error writing EPUB v2 TOC file: %w", err)
 	}
+	return nil
 }

--- a/write.go
+++ b/write.go
@@ -183,7 +183,6 @@ func createEpubFolders(rootEpubDir string) {
 // Write the contatiner file (container.xml), which mostly just points to the
 // package file (package.opf)
 //
-// Sample: https://github.com/bmaupin/epub-samples/blob/master/minimal-v3plus2/META-INF/container.xml
 // Spec: http://www.idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml
 func writeContainerFile(rootEpubDir string) {
 	containerFilePath := filepath.Join(rootEpubDir, metaInfFolderName, containerFilename)
@@ -403,7 +402,6 @@ func fixXMLId(id string) string {
 
 // Write the mimetype file
 //
-// Sample: https://github.com/bmaupin/epub-samples/blob/master/minimal-v3plus2/mimetype
 // Spec: http://www.idpf.org/epub/301/spec/epub-ocf.html#sec-zip-container-mime
 func writeMimetype(rootEpubDir string) {
 	mimetypeFilePath := filepath.Join(rootEpubDir, mimetypeFilename)

--- a/write.go
+++ b/write.go
@@ -73,7 +73,10 @@ func (e *Epub) WriteTo(dst io.Writer) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	createEpubFolders(tempDir)
+	err = createEpubFolders(tempDir)
+	if err != nil {
+		return 0, err
+	}
 
 	// Must be called after:
 	// createEpubFolders()
@@ -274,7 +277,7 @@ func (e *Epub) writeEpub(rootEpubDir string, dst io.Writer) (int64, error) {
 		var w io.Writer
 		if filepath.FromSlash(path) == filepath.Join(rootEpubDir, mimetypeFilename) {
 			// Skip the mimetype file if it's already been written
-			if skipMimetypeFile == true {
+			if skipMimetypeFile {
 				return nil
 			}
 			// The mimetype file must be uncompressed according to the EPUB spec
@@ -427,7 +430,10 @@ func writeMimetype(rootEpubDir string) error {
 }
 
 func (e *Epub) writePackageFile(rootEpubDir string) {
-	e.pkg.write(rootEpubDir)
+	err := e.pkg.write(rootEpubDir)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 // Write the section files to the temporary directory and add the sections to
@@ -449,7 +455,11 @@ func (e *Epub) writeSections(rootEpubDir string) {
 			}
 
 			sectionFilePath := filepath.Join(rootEpubDir, contentFolderName, xhtmlFolderName, section.filename)
-			section.xhtml.write(sectionFilePath)
+			err := section.xhtml.write(sectionFilePath)
+			if err != nil {
+				log.Println(err)
+			}
+
 			relativePath := filepath.Join(xhtmlFolderName, section.filename)
 
 			// The cover page should have already been added to the spine first
@@ -470,7 +480,10 @@ func (e *Epub) writeSections(rootEpubDir string) {
 						e.toc.addSubSection(relativePath, index, child.xhtml.Title(), relativeSubPath)
 
 						subSectionFilePath := filepath.Join(rootEpubDir, contentFolderName, xhtmlFolderName, child.filename)
-						child.xhtml.write(subSectionFilePath)
+						err = child.xhtml.write(subSectionFilePath)
+						if err != nil {
+							log.Println(err)
+						}
 
 						// Add subsection to spine
 						e.pkg.addToSpine(child.filename)
@@ -490,5 +503,9 @@ func (e *Epub) writeToc(rootEpubDir string) {
 	e.pkg.addToManifest(tocNavItemID, tocNavFilename, mediaTypeXhtml, tocNavItemProperties)
 	e.pkg.addToManifest(tocNcxItemID, tocNcxFilename, mediaTypeNcx, "")
 
-	e.toc.write(rootEpubDir)
+	err := e.toc.write(rootEpubDir)
+	if err != nil {
+		log.Println(err)
+	}
+
 }

--- a/write.go
+++ b/write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"unicode"
@@ -60,19 +61,26 @@ func (e *Epub) WriteTo(dst io.Writer) (int64, error) {
 
 	err := filesystem.Mkdir(tempDir, dirPermissions)
 	if err != nil {
-		panic(fmt.Sprintf("Error creating temp directory: %s", err))
+		return 0, fmt.Errorf("Error creating temp directory: %w", err)
+
 	}
 	defer func() {
 		if err := filesystem.RemoveAll(tempDir); err != nil {
-			panic(fmt.Sprintf("Error removing temp directory: %s", err))
+			log.Print("Error removing temp directory: %w", err)
 		}
 	}()
-	writeMimetype(tempDir)
+	err = writeMimetype(tempDir)
+	if err != nil {
+		return 0, err
+	}
 	createEpubFolders(tempDir)
 
 	// Must be called after:
 	// createEpubFolders()
-	writeContainerFile(tempDir)
+	err = writeContainerFile(tempDir)
+	if err != nil {
+		return 0, err
+	}
 
 	// Must be called after:
 	// createEpubFolders()
@@ -149,7 +157,7 @@ func (e *Epub) Write(destFilePath string) error {
 }
 
 // Create the EPUB folder structure in a temp directory
-func createEpubFolders(rootEpubDir string) {
+func createEpubFolders(rootEpubDir string) error {
 	if err := filesystem.Mkdir(
 		filepath.Join(
 			rootEpubDir,
@@ -157,7 +165,7 @@ func createEpubFolders(rootEpubDir string) {
 		),
 		dirPermissions); err != nil {
 		// No reason this should happen if tempDir creation was successful
-		panic(fmt.Sprintf("Error creating EPUB subdirectory: %s", err))
+		return fmt.Errorf("Error creating EPUB subdirectory: %w", err)
 	}
 
 	if err := filesystem.Mkdir(
@@ -167,7 +175,7 @@ func createEpubFolders(rootEpubDir string) {
 			xhtmlFolderName,
 		),
 		dirPermissions); err != nil {
-		panic(fmt.Sprintf("Error creating xhtml subdirectory: %s", err))
+		return fmt.Errorf("Error creating xhtml subdirectory: %w", err)
 	}
 
 	if err := filesystem.Mkdir(
@@ -176,15 +184,16 @@ func createEpubFolders(rootEpubDir string) {
 			metaInfFolderName,
 		),
 		dirPermissions); err != nil {
-		panic(fmt.Sprintf("Error creating META-INF subdirectory: %s", err))
+		return fmt.Errorf("Error creating META-INF subdirectory: %w", err)
 	}
+	return nil
 }
 
 // Write the contatiner file (container.xml), which mostly just points to the
 // package file (package.opf)
 //
 // Spec: http://www.idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml
-func writeContainerFile(rootEpubDir string) {
+func writeContainerFile(rootEpubDir string) error {
 	containerFilePath := filepath.Join(rootEpubDir, metaInfFolderName, containerFilename)
 	if err := filesystem.WriteFile(
 		containerFilePath,
@@ -197,8 +206,9 @@ func writeContainerFile(rootEpubDir string) {
 		),
 		filePermissions,
 	); err != nil {
-		panic(fmt.Sprintf("Error writing container file: %s", err))
+		return fmt.Errorf("Error writing container file: %w", err)
 	}
+	return nil
 }
 
 // Write the CSS files to the temporary directory and add them to the package
@@ -285,7 +295,7 @@ func (e *Epub) writeEpub(rootEpubDir string, dst io.Writer) (int64, error) {
 		}
 		defer func() {
 			if err := r.Close(); err != nil {
-				panic(err)
+				log.Println(err)
 			}
 		}()
 
@@ -301,14 +311,14 @@ func (e *Epub) writeEpub(rootEpubDir string, dst io.Writer) (int64, error) {
 	mimetypeInfo, err := fs.Stat(filesystem, mimetypeFilePath)
 	if err != nil {
 		if err := z.Close(); err != nil {
-			panic(err)
+			log.Println(err)
 		}
 		return counter.Total, fmt.Errorf("unable to get FileInfo for mimetype file: %w", err)
 	}
 	err = addFileToZip(mimetypeFilePath, fileInfoToDirEntry(mimetypeInfo), nil)
 	if err != nil {
 		if err := z.Close(); err != nil {
-			panic(err)
+			log.Println(err)
 		}
 		return counter.Total, fmt.Errorf("unable to add mimetype file to EPUB: %w", err)
 	}
@@ -318,7 +328,7 @@ func (e *Epub) writeEpub(rootEpubDir string, dst io.Writer) (int64, error) {
 	err = fs.WalkDir(filesystem, rootEpubDir, addFileToZip)
 	if err != nil {
 		if err := z.Close(); err != nil {
-			panic(err)
+			log.Println(err)
 		}
 		return counter.Total, fmt.Errorf("unable to add file to EPUB: %w", err)
 	}
@@ -367,7 +377,11 @@ func (e *Epub) writeMedia(rootEpubDir string, mediaMap map[string]string, mediaF
 			}
 
 			// Add the file to the OPF manifest
-			e.pkg.addToManifest(fixXMLId(mediaFilename), filepath.Join(mediaFolderName, mediaFilename), mediaType, mediaProperties)
+			xmlId, err := fixXMLId(mediaFilename)
+			if err != nil {
+				return fmt.Errorf("error creating xml id: %w", err)
+			}
+			e.pkg.addToManifest(xmlId, filepath.Join(mediaFolderName, mediaFilename), mediaType, mediaProperties)
 		}
 	}
 	return nil
@@ -377,9 +391,9 @@ func (e *Epub) writeMedia(rootEpubDir string, mediaMap map[string]string, mediaF
 // https://www.w3.org/TR/REC-xml-names/#NT-NCName
 // This means it must not contain a colon (:) or whitespace and it must not
 // start with a digit, punctuation or diacritics
-func fixXMLId(id string) string {
+func fixXMLId(id string) (string, error) {
 	if len(id) == 0 {
-		panic("No id given")
+		return "", fmt.Errorf("no id given")
 	}
 	fixedId := []rune{}
 	for i := 0; len(id) > 0; i++ {
@@ -397,18 +411,19 @@ func fixXMLId(id string) string {
 		}
 		id = id[size:]
 	}
-	return string(fixedId)
+	return string(fixedId), nil
 }
 
 // Write the mimetype file
 //
 // Spec: http://www.idpf.org/epub/301/spec/epub-ocf.html#sec-zip-container-mime
-func writeMimetype(rootEpubDir string) {
+func writeMimetype(rootEpubDir string) error {
 	mimetypeFilePath := filepath.Join(rootEpubDir, mimetypeFilename)
 
 	if err := filesystem.WriteFile(mimetypeFilePath, []byte(mediaTypeEpub), filePermissions); err != nil {
-		panic(fmt.Sprintf("Error writing mimetype file: %s", err))
+		return fmt.Errorf("Error writing mimetype file: %w", err)
 	}
+	return nil
 }
 
 func (e *Epub) writePackageFile(rootEpubDir string) {

--- a/write.go
+++ b/write.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gofrs/uuid"
+	"github.com/gofrs/uuid/v5"
 )
 
 // UnableToCreateEpubError is thrown by Write if it cannot create the destination EPUB file
@@ -380,9 +380,9 @@ func fixXMLId(id string) string {
 	if len(id) == 0 {
 		panic("No id given")
 	}
-	newid := uuid.Must(uuid.NewV4()).String()
-	fixedId := fmt.Sprintf("id%s", newid)
-	return string(fixedId)
+	namespace := uuid.NewV5(uuid.NamespaceURL, "github.com/go-shiori/go-epub")
+	fileIdentifier := fmt.Sprintf("id%s", uuid.NewV5(namespace, id))
+	return fileIdentifier
 }
 
 // Write the mimetype file

--- a/write.go
+++ b/write.go
@@ -7,8 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/gofrs/uuid"
 )
@@ -382,22 +380,8 @@ func fixXMLId(id string) string {
 	if len(id) == 0 {
 		panic("No id given")
 	}
-	fixedId := []rune{}
-	for i := 0; len(id) > 0; i++ {
-		r, size := utf8.DecodeRuneInString(id)
-		if i == 0 {
-			// The new id should be prefixed with 'id' if an invalid
-			// starting character is found
-			// this is not 100% accurate, but a better check than no check
-			if unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
-				fixedId = append(fixedId, []rune("id")...)
-			}
-		}
-		if !unicode.IsSpace(r) && r != ':' {
-			fixedId = append(fixedId, r)
-		}
-		id = id[size:]
-	}
+	newid := uuid.Must(uuid.NewV4()).String()
+	fixedId := fmt.Sprintf("id%s", newid)
 	return string(fixedId)
 }
 

--- a/write_test.go
+++ b/write_test.go
@@ -3,7 +3,6 @@ package epub
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,11 +68,15 @@ func testWriteToErrors(t *testing.T, e *Epub, adder func(string, string) (string
 		t.Fatalf("cannot open testdata: %v", err)
 	}
 	defer data.Close()
-	temp, err := ioutil.TempFile("", "temp")
+	temp, err := os.CreateTemp("", "temp")
 	if err != nil {
 		t.Fatalf("unable to create temp file: %v", err)
 	}
-	io.Copy(temp, data)
+	_, err = io.Copy(temp, data)
+	if err != nil {
+		t.Fatalf("unable to copy tmp file to destination: %v", err)
+	}
+
 	temp.Close()
 	// Add temp file to epub
 	if _, err := adder(temp.Name(), ""); err != nil {

--- a/write_test.go
+++ b/write_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 func TestEpubWriteTo(t *testing.T) {
-	e := NewEpub(testEpubTitle)
+	e, err := NewEpub(testEpubTitle)
+	if err != nil {
+		t.Error(err)
+	}
 	var b bytes.Buffer
 	n, err := e.WriteTo(&b)
 	if err != nil {
@@ -23,23 +26,38 @@ func TestEpubWriteTo(t *testing.T) {
 
 func TestWriteToErrors(t *testing.T) {
 	t.Run("CSS", func(t *testing.T) {
-		e := NewEpub(testEpubTitle)
+		e, err := NewEpub(testEpubTitle)
+		if err != nil {
+			t.Error(err)
+		}
 		testWriteToErrors(t, e, e.AddCSS, "cover.css")
 	})
 	t.Run("Font", func(t *testing.T) {
-		e := NewEpub(testEpubTitle)
+		e, err := NewEpub(testEpubTitle)
+		if err != nil {
+			t.Error(err)
+		}
 		testWriteToErrors(t, e, e.AddFont, "redacted-script-regular.ttf")
 	})
 	t.Run("Image", func(t *testing.T) {
-		e := NewEpub(testEpubTitle)
+		e, err := NewEpub(testEpubTitle)
+		if err != nil {
+			t.Error(err)
+		}
 		testWriteToErrors(t, e, e.AddImage, "gophercolor16x16.png")
 	})
 	t.Run("Video", func(t *testing.T) {
-		e := NewEpub(testEpubTitle)
+		e, err := NewEpub(testEpubTitle)
+		if err != nil {
+			t.Error(err)
+		}
 		testWriteToErrors(t, e, e.AddVideo, "sample_640x360.mp4")
 	})
 	t.Run("Audio", func(t *testing.T) {
-		e := NewEpub(testEpubTitle)
+		e, err := NewEpub(testEpubTitle)
+		if err != nil {
+			t.Error(err)
+		}
 		testWriteToErrors(t, e, e.AddAudio, "sample_audio.wav")
 	})
 }


### PR DESCRIPTION
EmbededImage add same URL how many times it exist in HTML file that make unnecessary big file and some other problem. this PR download and add image to epub just once and reference all of same url image to the same file inside epub.


1. not download image twice
2. better id for images in opf file Fix #70 
3. fix content of image tag inside HTML to show correctly in eBooks reader.
